### PR TITLE
SSH Access to Lab Nodes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # .env.example
 API_PORT=8080
+API_SERVER_HOST=localhost
 JWT_SECRET=a_very_secret_key_change_me_please # CHANGE THIS! Use a strong, random secret
 JWT_EXPIRATION_MINUTES=60m
 # API_USER_GROUP=clab_api # The API group name, if not defined, the user needs to be in clab_admins group

--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,12 @@ CLAB_RUNTIME=docker # The runtime to use for the labs
 LOG_LEVEL=debug
 
 # Gin Settings
-GIN_MODE=debug       # Options: debug, release, test
+GIN_MODE=release       # Options: debug, release, test
 TRUSTED_PROXIES=     # Options: nil (trust none), comma-separated IPs, or empty (trust all)
+
+# SSH proxy port range (Default: 2222-2322)
+#SSH_BASE_PORT=2222
+#SSH_MAX_PORT=2322
 
 # --- TLS Configuration ---
 #TLS_ENABLE=true

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,8 +2,8 @@
 package main
 
 import (
-	"context" // Import context
-	"errors"  // Import errors
+	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -12,7 +12,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
-	"time" // Import time
+	"time"
 
 	"github.com/charmbracelet/log"
 	"github.com/gin-gonic/gin"
@@ -89,14 +89,12 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 	case "info":
 		log.SetLevel(log.InfoLevel)
-	// ... other levels ...
 	default:
 		log.Warnf("Invalid LOG_LEVEL '%s', defaulting to 'info'", config.AppConfig.LogLevel)
 		log.SetLevel(log.InfoLevel)
 	}
 	log.Infof("clab-api-server version %s starting...", version)
 	log.Infof("Configuration processed. Log level set to '%s'.", config.AppConfig.LogLevel)
-	// ... log other config details ...
 	if config.AppConfig.JWTSecret == "default_secret_change_me" {
 		log.Warn("Using default JWT secret. Change JWT_SECRET environment variable or .env file for production!")
 	}
@@ -122,7 +120,6 @@ func main() {
 	router := gin.Default() // Use Default for logging and recovery middleware
 
 	// Configure trusted proxies
-	// ... (proxy configuration logic remains the same) ...
 	if config.AppConfig.TrustedProxies == "nil" {
 		log.Info("Proxy trust disabled (TRUSTED_PROXIES=nil)")
 		_ = router.SetTrustedProxies(nil)
@@ -144,7 +141,6 @@ func main() {
 
 	// Root handler (remains the same)
 	router.GET("/", func(c *gin.Context) {
-		// ... root handler logic ...
 		protocol := "http"
 		if config.AppConfig.TLSEnable {
 			protocol = "https"
@@ -171,19 +167,15 @@ func main() {
 	})
 
 	// --- Prepare Server Configuration ---
-	listenAddr := fmt.Sprintf(":%s", config.AppConfig.APIPort)                    // Define ONCE here
-	serverBaseURL := fmt.Sprintf("http://localhost:%s", config.AppConfig.APIPort) // Define ONCE here
+	listenAddr := fmt.Sprintf(":%s", config.AppConfig.APIPort)
+	serverBaseURL := fmt.Sprintf("http://localhost:%s", config.AppConfig.APIPort)
 	if config.AppConfig.TLSEnable {
-		serverBaseURL = fmt.Sprintf("https://localhost:%s", config.AppConfig.APIPort) // Adjust if TLS
+		serverBaseURL = fmt.Sprintf("https://localhost:%s", config.AppConfig.APIPort)
 	}
 
 	srv := &http.Server{
 		Addr:    listenAddr,
-		Handler: router, // Use the Gin engine as the handler
-		// Consider adding timeouts for production hardening:
-		// ReadTimeout:  5 * time.Second,
-		// WriteTimeout: 10 * time.Second,
-		// IdleTimeout:  120 * time.Second,
+		Handler: router,
 	}
 
 	// --- Start Server Goroutine ---

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -110,6 +110,7 @@ func main() {
 	// --- Initialize SSH Manager ---
 	log.Info("Initializing SSH Session Manager...")
 	api.InitSSHManager() // Initialize before setting up routes
+	log.Infof("SSH port range configured: %d - %d", config.AppConfig.SSHBasePort, config.AppConfig.SSHMaxPort)
 
 	// --- Initialize Gin router ---
 	if strings.ToLower(config.AppConfig.GinMode) == "release" {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -951,7 +951,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Node name within the lab (not the full container name)",
+                        "description": "Full container name of the node (e.g., clab-my-lab-srl1)",
                         "name": "nodeName",
                         "in": "path",
                         "required": true
@@ -1076,7 +1076,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Lists all active SSH sessions for the authenticated user",
+                "description": "Lists active SSH sessions. For regular users, shows only their sessions. Superusers can see all sessions by using the 'all' query parameter.",
                 "produces": [
                     "application/json"
                 ],
@@ -1084,6 +1084,14 @@ const docTemplate = `{
                     "SSH Access"
                 ],
                 "summary": "List SSH Sessions",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "If true and user is superuser, shows sessions for all users (default: false)",
+                        "name": "all",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "List of active SSH sessions",
@@ -1096,6 +1104,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden (non-superuser attempting to list all sessions)",
                         "schema": {
                             "$ref": "#/definitions/models.ErrorResponse"
                         }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -923,6 +923,88 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/labs/{labName}/nodes/{nodeName}/ssh": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Creates temporary SSH access to a specific lab node, returning connection details",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "SSH Access"
+                ],
+                "summary": "Request SSH Access to Lab Node",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Lab name",
+                        "name": "labName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Node name within the lab (not the full container name)",
+                        "name": "nodeName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "SSH access parameters",
+                        "name": "sshRequest",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/models.SSHAccessRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "SSH connection details",
+                        "schema": {
+                            "$ref": "#/definitions/models.SSHAccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden (not owner of the lab)",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Lab or node not found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/labs/{labName}/save": {
             "post": {
                 "security": [
@@ -980,6 +1062,104 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal server error or clab execution failed",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/ssh/sessions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Lists all active SSH sessions for the authenticated user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "SSH Access"
+                ],
+                "summary": "List SSH Sessions",
+                "responses": {
+                    "200": {
+                        "description": "List of active SSH sessions",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.SSHSessionInfo"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/ssh/sessions/{port}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Terminates a specific SSH session by port",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "SSH Access"
+                ],
+                "summary": "Terminate SSH Session",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "SSH session port to terminate",
+                        "name": "port",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Session terminated successfully",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericSuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid port parameter",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden (not owner of the session)",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Session not found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/models.ErrorResponse"
                         }
@@ -2080,6 +2260,73 @@ const docTemplate = `{
                 }
             }
         },
+        "models.SSHAccessRequest": {
+            "type": "object",
+            "properties": {
+                "duration": {
+                    "description": "How long the access should be valid for (e.g., \"1h\", \"30m\")",
+                    "type": "string"
+                },
+                "sshUsername": {
+                    "description": "Optional override for container's SSH user",
+                    "type": "string"
+                }
+            }
+        },
+        "models.SSHAccessResponse": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "description": "Example SSH command",
+                    "type": "string"
+                },
+                "expiration": {
+                    "description": "When this access expires",
+                    "type": "string"
+                },
+                "host": {
+                    "description": "API server's hostname or IP",
+                    "type": "string"
+                },
+                "port": {
+                    "description": "Allocated port on API server",
+                    "type": "integer"
+                },
+                "username": {
+                    "description": "Username to use for SSH",
+                    "type": "string"
+                }
+            }
+        },
+        "models.SSHSessionInfo": {
+            "type": "object",
+            "properties": {
+                "created": {
+                    "description": "When this access was created",
+                    "type": "string"
+                },
+                "expiration": {
+                    "description": "When this access expires",
+                    "type": "string"
+                },
+                "labName": {
+                    "description": "Lab name",
+                    "type": "string"
+                },
+                "nodeName": {
+                    "description": "Node name",
+                    "type": "string"
+                },
+                "port": {
+                    "description": "Allocated port on API server",
+                    "type": "integer"
+                },
+                "username": {
+                    "description": "SSH username",
+                    "type": "string"
+                }
+            }
+        },
         "models.SaveConfigResponse": {
             "type": "object",
             "properties": {
@@ -2189,7 +2436,7 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "1.0 // This swagger version is separate from the application version",
+	Version:          "1.0",
 	Host:             "",
 	BasePath:         "",
 	Schemes:          []string{"http", "https"},

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -17,7 +17,7 @@
             "name": "Apache 2.0",
             "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
         },
-        "version": "1.0 // This swagger version is separate from the application version"
+        "version": "1.0"
     },
     "paths": {
         "/api/v1/generate": {
@@ -919,6 +919,88 @@
                 }
             }
         },
+        "/api/v1/labs/{labName}/nodes/{nodeName}/ssh": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Creates temporary SSH access to a specific lab node, returning connection details",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "SSH Access"
+                ],
+                "summary": "Request SSH Access to Lab Node",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Lab name",
+                        "name": "labName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Node name within the lab (not the full container name)",
+                        "name": "nodeName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "SSH access parameters",
+                        "name": "sshRequest",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/models.SSHAccessRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "SSH connection details",
+                        "schema": {
+                            "$ref": "#/definitions/models.SSHAccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden (not owner of the lab)",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Lab or node not found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/labs/{labName}/save": {
             "post": {
                 "security": [
@@ -976,6 +1058,104 @@
                     },
                     "500": {
                         "description": "Internal server error or clab execution failed",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/ssh/sessions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Lists all active SSH sessions for the authenticated user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "SSH Access"
+                ],
+                "summary": "List SSH Sessions",
+                "responses": {
+                    "200": {
+                        "description": "List of active SSH sessions",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.SSHSessionInfo"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/ssh/sessions/{port}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Terminates a specific SSH session by port",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "SSH Access"
+                ],
+                "summary": "Terminate SSH Session",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "SSH session port to terminate",
+                        "name": "port",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Session terminated successfully",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericSuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid port parameter",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden (not owner of the session)",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Session not found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/models.ErrorResponse"
                         }
@@ -2073,6 +2253,73 @@
                 "skipPostDeploy": {
                     "description": "Corresponds to --skip-post-deploy flag",
                     "type": "boolean"
+                }
+            }
+        },
+        "models.SSHAccessRequest": {
+            "type": "object",
+            "properties": {
+                "duration": {
+                    "description": "How long the access should be valid for (e.g., \"1h\", \"30m\")",
+                    "type": "string"
+                },
+                "sshUsername": {
+                    "description": "Optional override for container's SSH user",
+                    "type": "string"
+                }
+            }
+        },
+        "models.SSHAccessResponse": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "description": "Example SSH command",
+                    "type": "string"
+                },
+                "expiration": {
+                    "description": "When this access expires",
+                    "type": "string"
+                },
+                "host": {
+                    "description": "API server's hostname or IP",
+                    "type": "string"
+                },
+                "port": {
+                    "description": "Allocated port on API server",
+                    "type": "integer"
+                },
+                "username": {
+                    "description": "Username to use for SSH",
+                    "type": "string"
+                }
+            }
+        },
+        "models.SSHSessionInfo": {
+            "type": "object",
+            "properties": {
+                "created": {
+                    "description": "When this access was created",
+                    "type": "string"
+                },
+                "expiration": {
+                    "description": "When this access expires",
+                    "type": "string"
+                },
+                "labName": {
+                    "description": "Lab name",
+                    "type": "string"
+                },
+                "nodeName": {
+                    "description": "Node name",
+                    "type": "string"
+                },
+                "port": {
+                    "description": "Allocated port on API server",
+                    "type": "integer"
+                },
+                "username": {
+                    "description": "SSH username",
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -947,7 +947,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Node name within the lab (not the full container name)",
+                        "description": "Full container name of the node (e.g., clab-my-lab-srl1)",
                         "name": "nodeName",
                         "in": "path",
                         "required": true
@@ -1072,7 +1072,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Lists all active SSH sessions for the authenticated user",
+                "description": "Lists active SSH sessions. For regular users, shows only their sessions. Superusers can see all sessions by using the 'all' query parameter.",
                 "produces": [
                     "application/json"
                 ],
@@ -1080,6 +1080,14 @@
                     "SSH Access"
                 ],
                 "summary": "List SSH Sessions",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "If true and user is superuser, shows sessions for all users (default: false)",
+                        "name": "all",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "List of active SSH sessions",
@@ -1092,6 +1100,12 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden (non-superuser attempting to list all sessions)",
                         "schema": {
                             "$ref": "#/definitions/models.ErrorResponse"
                         }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -471,6 +471,54 @@ definitions:
         description: Corresponds to --skip-post-deploy flag
         type: boolean
     type: object
+  models.SSHAccessRequest:
+    properties:
+      duration:
+        description: How long the access should be valid for (e.g., "1h", "30m")
+        type: string
+      sshUsername:
+        description: Optional override for container's SSH user
+        type: string
+    type: object
+  models.SSHAccessResponse:
+    properties:
+      command:
+        description: Example SSH command
+        type: string
+      expiration:
+        description: When this access expires
+        type: string
+      host:
+        description: API server's hostname or IP
+        type: string
+      port:
+        description: Allocated port on API server
+        type: integer
+      username:
+        description: Username to use for SSH
+        type: string
+    type: object
+  models.SSHSessionInfo:
+    properties:
+      created:
+        description: When this access was created
+        type: string
+      expiration:
+        description: When this access expires
+        type: string
+      labName:
+        description: Lab name
+        type: string
+      nodeName:
+        description: Node name
+        type: string
+      port:
+        description: Allocated port on API server
+        type: integer
+      username:
+        description: SSH username
+        type: string
+    type: object
   models.SaveConfigResponse:
     properties:
       message:
@@ -567,7 +615,7 @@ info:
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   termsOfService: http://swagger.io/terms/
   title: Containerlab API
-  version: 1.0 // This swagger version is separate from the application version
+  version: "1.0"
 paths:
   /api/v1/generate:
     post:
@@ -1110,6 +1158,60 @@ paths:
       summary: Show Network Emulation
       tags:
       - Tools - Netem
+  /api/v1/labs/{labName}/nodes/{nodeName}/ssh:
+    post:
+      consumes:
+      - application/json
+      description: Creates temporary SSH access to a specific lab node, returning
+        connection details
+      parameters:
+      - description: Lab name
+        in: path
+        name: labName
+        required: true
+        type: string
+      - description: Node name within the lab (not the full container name)
+        in: path
+        name: nodeName
+        required: true
+        type: string
+      - description: SSH access parameters
+        in: body
+        name: sshRequest
+        schema:
+          $ref: '#/definitions/models.SSHAccessRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: SSH connection details
+          schema:
+            $ref: '#/definitions/models.SSHAccessResponse'
+        "400":
+          description: Invalid request parameters
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "403":
+          description: Forbidden (not owner of the lab)
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "404":
+          description: Lab or node not found
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Request SSH Access to Lab Node
+      tags:
+      - SSH Access
   /api/v1/labs/{labName}/save:
     post:
       description: Saves the running configuration for nodes in a specific lab. Checks
@@ -1233,6 +1335,68 @@ paths:
       summary: Deploy Lab from Archive
       tags:
       - Labs
+  /api/v1/ssh/sessions:
+    get:
+      description: Lists all active SSH sessions for the authenticated user
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of active SSH sessions
+          schema:
+            items:
+              $ref: '#/definitions/models.SSHSessionInfo'
+            type: array
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: List SSH Sessions
+      tags:
+      - SSH Access
+  /api/v1/ssh/sessions/{port}:
+    delete:
+      description: Terminates a specific SSH session by port
+      parameters:
+      - description: SSH session port to terminate
+        in: path
+        name: port
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Session terminated successfully
+          schema:
+            $ref: '#/definitions/models.GenericSuccessResponse'
+        "400":
+          description: Invalid port parameter
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "403":
+          description: Forbidden (not owner of the session)
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "404":
+          description: Session not found
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Terminate SSH Session
+      tags:
+      - SSH Access
   /api/v1/tools/certs/ca:
     post:
       consumes:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1170,7 +1170,7 @@ paths:
         name: labName
         required: true
         type: string
-      - description: Node name within the lab (not the full container name)
+      - description: Full container name of the node (e.g., clab-my-lab-srl1)
         in: path
         name: nodeName
         required: true
@@ -1337,7 +1337,14 @@ paths:
       - Labs
   /api/v1/ssh/sessions:
     get:
-      description: Lists all active SSH sessions for the authenticated user
+      description: Lists active SSH sessions. For regular users, shows only their
+        sessions. Superusers can see all sessions by using the 'all' query parameter.
+      parameters:
+      - description: 'If true and user is superuser, shows sessions for all users
+          (default: false)'
+        in: query
+        name: all
+        type: boolean
       produces:
       - application/json
       responses:
@@ -1349,6 +1356,10 @@ paths:
             type: array
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "403":
+          description: Forbidden (non-superuser attempting to list all sessions)
           schema:
             $ref: '#/definitions/models.ErrorResponse'
       security:

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -5,7 +5,7 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
-	"context" // Import context
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -136,7 +136,6 @@ func getUserCertBasePath(username string) (string, error) {
 		return "", fmt.Errorf("could not retrieve user details for '%s'", username)
 	}
 
-	// --- NEW PATH: Use user's home directory ---
 	// Store certs under ~/.clab/certs (consistent with potential user clab usage)
 	basePath := filepath.Join(usr.HomeDir, ".clab", "certs")
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	"github.com/srl-labs/clab-api-server/internal/auth" // Adjust import path
+	"github.com/srl-labs/clab-api-server/internal/auth"
 	"github.com/srl-labs/clab-api-server/internal/models"
 )
 

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -6,7 +6,6 @@ import (
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
 
-	// Adjust import path if your module path is different
 	_ "github.com/srl-labs/clab-api-server/docs"
 )
 
@@ -77,7 +76,7 @@ func SetupRoutes(router *gin.Engine) {
 					}
 				}
 			}
-		} // End /labs group
+		}
 
 		// SSH Session Management Routes (Global)
 		ssh := apiV1.Group("/ssh")
@@ -87,7 +86,7 @@ func SetupRoutes(router *gin.Engine) {
 
 			// Terminate a specific SSH session by port
 			ssh.DELETE("/sessions/:port", TerminateSSHSessionHandler) // DELETE /api/v1/ssh/sessions/{port}
-		} // End /ssh group
+		}
 
 		// Topology Generation Route
 		apiV1.POST("/generate", GenerateTopologyHandler) // POST /api/v1/generate
@@ -113,16 +112,16 @@ func SetupRoutes(router *gin.Engine) {
 			{
 				vxlan.POST("", CreateVxlanHandler)   // POST /api/v1/tools/vxlan
 				vxlan.DELETE("", DeleteVxlanHandler) // DELETE /api/v1/tools/vxlan
-			} // End /vxlan group
+			}
 
-		} // End /tools group
+		}
 
 		// Version Info Routes
 		version := apiV1.Group("/version")
 		{
 			version.GET("", GetVersionHandler)         // GET /api/v1/version
 			version.GET("/check", CheckVersionHandler) // GET /api/v1/version/check
-		} // End /version group
+		}
 
-	} // End /api/v1 group
+	}
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/srl-labs/clab-api-server/docs"
 )
 
+// SetupRoutes defines all the API endpoints and applies middleware.
 func SetupRoutes(router *gin.Engine) {
 	// --- Public Routes ---
 
@@ -17,11 +18,12 @@ func SetupRoutes(router *gin.Engine) {
 	router.POST("/login", LoginHandler)
 
 	// Swagger documentation route
+	// URL needs to match the basePath in your main swagger annotations
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, ginSwagger.URL("/swagger/doc.json")))
 
 	// --- Authenticated Routes (/api/v1) ---
 	apiV1 := router.Group("/api/v1")
-	apiV1.Use(AuthMiddleware()) // Apply JWT authentication middleware
+	apiV1.Use(AuthMiddleware()) // Apply JWT authentication middleware to all /api/v1 routes
 	{
 		// Lab management routes
 		labs := apiV1.Group("/labs")
@@ -29,10 +31,10 @@ func SetupRoutes(router *gin.Engine) {
 			// Deploy new lab (JSON/URL method)
 			labs.POST("", DeployLabHandler) // POST /api/v1/labs
 
-			// Deploy new lab (Archive method) - NEW
+			// Deploy new lab (Archive method)
 			labs.POST("/archive", DeployLabArchiveHandler) // POST /api/v1/labs/archive
 
-			// List labs for user
+			// List labs for user (or all if superuser)
 			labs.GET("", ListLabsHandler) // GET /api/v1/labs
 
 			// Actions on a specific lab by name
@@ -56,12 +58,16 @@ func SetupRoutes(router *gin.Engine) {
 				// Execute Command in Lab
 				labSpecific.POST("/exec", ExecCommandHandler) // POST /api/v1/labs/{labName}/exec
 
-				// Netem Routes (nested under node)
+				// Node Specific Routes (nested under lab)
 				nodeSpecific := labSpecific.Group("/nodes/:nodeName")
 				{
+					// Request SSH Access to a specific node
+					nodeSpecific.POST("/ssh", RequestSSHAccessHandler) // POST /api/v1/labs/{labName}/nodes/{nodeName}/ssh
+
 					// Show netem for all interfaces on node
 					nodeSpecific.GET("/netem", ShowNetemHandler) // GET /api/v1/labs/{labName}/nodes/{nodeName}/netem
 
+					// Interface Specific Routes (nested under node)
 					interfaceSpecific := nodeSpecific.Group("/interfaces/:interfaceName")
 					{
 						// Set netem for specific interface
@@ -71,12 +77,22 @@ func SetupRoutes(router *gin.Engine) {
 					}
 				}
 			}
-		}
+		} // End /labs group
 
-		// Topology Generation Route ---
+		// SSH Session Management Routes (Global)
+		ssh := apiV1.Group("/ssh")
+		{
+			// List active SSH sessions for the user (or all if superuser)
+			ssh.GET("/sessions", ListSSHSessionsHandler) // GET /api/v1/ssh/sessions
+
+			// Terminate a specific SSH session by port
+			ssh.DELETE("/sessions/:port", TerminateSSHSessionHandler) // DELETE /api/v1/ssh/sessions/{port}
+		} // End /ssh group
+
+		// Topology Generation Route
 		apiV1.POST("/generate", GenerateTopologyHandler) // POST /api/v1/generate
 
-		// Tools Routes (Top Level, mostly Superuser)
+		// Tools Routes (Mostly Superuser)
 		tools := apiV1.Group("/tools")
 		{
 			// Disable TX Offload (Superuser Only)
@@ -87,20 +103,26 @@ func SetupRoutes(router *gin.Engine) {
 			{
 				certs.POST("/ca", CreateCAHandler)   // POST /api/v1/tools/certs/ca
 				certs.POST("/sign", SignCertHandler) // POST /api/v1/tools/certs/sign
-			}
+			} // End /certs group
+
 			// vEth Tools (Superuser Only)
 			tools.POST("/veth", CreateVethHandler) // POST /api/v1/tools/veth
 
 			// VxLAN Tools (Superuser Only)
-			tools.POST("/vxlan", CreateVxlanHandler)   // POST /api/v1/tools/vxlan
-			tools.DELETE("/vxlan", DeleteVxlanHandler) // DELETE
-		}
+			vxlan := tools.Group("/vxlan")
+			{
+				vxlan.POST("", CreateVxlanHandler)   // POST /api/v1/tools/vxlan
+				vxlan.DELETE("", DeleteVxlanHandler) // DELETE /api/v1/tools/vxlan
+			} // End /vxlan group
 
-		// --- NEW: Version Info Routes ---
+		} // End /tools group
+
+		// Version Info Routes
 		version := apiV1.Group("/version")
 		{
 			version.GET("", GetVersionHandler)         // GET /api/v1/version
 			version.GET("/check", CheckVersionHandler) // GET /api/v1/version/check
-		}
-	}
+		} // End /version group
+
+	} // End /api/v1 group
 }

--- a/internal/api/ssh_handlers.go
+++ b/internal/api/ssh_handlers.go
@@ -23,8 +23,8 @@ var sshManager *ssh.SSHManager
 // InitSSHManager initializes the SSH manager
 func InitSSHManager() {
 	sshManager = ssh.NewSSHManager(
-		ssh.DefaultSSHBasePort,
-		ssh.DefaultSSHMaxPort,
+		config.AppConfig.SSHBasePort,
+		config.AppConfig.SSHMaxPort,
 		ssh.DefaultSSHCleanupTick,
 		ssh.DefaultSSHSessionTimeout,
 	)
@@ -56,7 +56,7 @@ func ShutdownSSHManager() {
 func RequestSSHAccessHandler(c *gin.Context) {
 	username := c.GetString("username")
 	labName := c.Param("labName")
-	containerName := c.Param("nodeName") // This is now expected to be the full container name
+	containerName := c.Param("nodeName")
 
 	// Validate inputs
 	if !isValidLabName(labName) {
@@ -293,14 +293,4 @@ func getAPIServerHost(r *http.Request) string {
 	}
 
 	return host
-}
-
-// Helper function for validating node names
-func isValidNodeName(name string) bool {
-	if name == "" || len(name) > 128 {
-		return false
-	}
-
-	// Similar to labNameRegex but might be different for your specific needs
-	return labNameRegex.MatchString(name)
 }

--- a/internal/api/ssh_handlers.go
+++ b/internal/api/ssh_handlers.go
@@ -260,7 +260,6 @@ func TerminateSSHSessionHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, models.GenericSuccessResponse{Message: "SSH session terminated successfully."})
 }
 
-// Helper function to get API server host, respecting proxies and headers
 // Helper function to get API server host, respecting config, proxies and headers
 func getAPIServerHost(r *http.Request) string {
 	// First check if API_SERVER_HOST is explicitly configured

--- a/internal/api/ssh_handlers.go
+++ b/internal/api/ssh_handlers.go
@@ -1,0 +1,278 @@
+// internal/api/ssh_handlers.go
+package api
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/log"
+	"github.com/gin-gonic/gin"
+
+	"github.com/srl-labs/clab-api-server/internal/models"
+	"github.com/srl-labs/clab-api-server/internal/ssh"
+)
+
+// Global SSH manager instance
+var sshManager *ssh.SSHManager
+
+// InitSSHManager initializes the SSH manager
+func InitSSHManager() {
+	sshManager = ssh.NewSSHManager(
+		ssh.DefaultSSHBasePort,
+		ssh.DefaultSSHMaxPort,
+		ssh.DefaultSSHCleanupTick,
+		ssh.DefaultSSHSessionTimeout,
+	)
+}
+
+// ShutdownSSHManager gracefully shuts down the SSH manager
+func ShutdownSSHManager() {
+	if sshManager != nil {
+		sshManager.Shutdown()
+	}
+}
+
+// @Summary Request SSH Access to Lab Node
+// @Description Creates temporary SSH access to a specific lab node, returning connection details
+// @Tags SSH Access
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param labName path string true "Lab name" example="my-lab"
+// @Param nodeName path string true "Node name within the lab (not the full container name)" example="srl1"
+// @Param sshRequest body models.SSHAccessRequest false "SSH access parameters"
+// @Success 200 {object} models.SSHAccessResponse "SSH connection details"
+// @Failure 400 {object} models.ErrorResponse "Invalid request parameters"
+// @Failure 401 {object} models.ErrorResponse "Unauthorized"
+// @Failure 403 {object} models.ErrorResponse "Forbidden (not owner of the lab)"
+// @Failure 404 {object} models.ErrorResponse "Lab or node not found"
+// @Failure 500 {object} models.ErrorResponse "Internal server error"
+// @Router /api/v1/labs/{labName}/nodes/{nodeName}/ssh [post]
+func RequestSSHAccessHandler(c *gin.Context) {
+	username := c.GetString("username")
+	labName := c.Param("labName")
+	nodeName := c.Param("nodeName")
+
+	// Validate inputs
+	if !isValidLabName(labName) {
+		log.Warnf("SSH Access failed for user '%s': Invalid lab name '%s'", username, labName)
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "Invalid lab name format."})
+		return
+	}
+
+	if !isValidNodeName(nodeName) {
+		log.Warnf("SSH Access failed for user '%s': Invalid node name '%s'", username, nodeName)
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "Invalid node name format."})
+		return
+	}
+
+	// Parse request
+	var req models.SSHAccessRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		// Empty request is fine, we'll use defaults
+		if err != io.EOF {
+			log.Warnf("SSH Access failed for user '%s': Invalid request body: %v", username, err)
+			c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "Invalid request format: " + err.Error()})
+			return
+		}
+	}
+
+	// Set defaults and validate request parameters
+	sshUsername := req.SSHUsername
+	if sshUsername == "" {
+		sshUsername = "admin" // Most network devices use admin or root
+	}
+
+	duration := ssh.DefaultSSHSessionTimeout
+	if req.Duration != "" {
+		var err error
+		duration, err = time.ParseDuration(req.Duration)
+		if err != nil {
+			log.Warnf("SSH Access failed for user '%s': Invalid duration '%s'", username, req.Duration)
+			c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "Invalid duration format. Use values like '1h', '30m'."})
+			return
+		}
+
+		if duration > ssh.MaxSSHSessionDuration {
+			duration = ssh.MaxSSHSessionDuration
+		}
+	}
+
+	// Verify lab ownership
+	_, err := verifyLabOwnership(c, username, labName)
+	if err != nil {
+		// verifyLabOwnership already sent response
+		return
+	}
+
+	// Get container (node) details
+	// Construct the full container name as clab-<labName>-<nodeName>
+	containerName := fmt.Sprintf("clab-%s-%s", labName, nodeName)
+	containerInfo, err := verifyContainerOwnership(c, username, containerName)
+	if err != nil {
+		// verifyContainerOwnership already sent response
+		return
+	}
+
+	// Extract container IP for SSH access
+	containerIP := containerInfo.IPv4Address
+	if containerIP == "" {
+		log.Warnf("SSH Access failed for user '%s': Container '%s' has no IPv4 address", username, containerName)
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{Error: "Container has no IPv4 address for SSH access."})
+		return
+	}
+
+	// Extract IP without CIDR notation if present
+	if strings.Contains(containerIP, "/") {
+		containerIP = strings.Split(containerIP, "/")[0]
+	}
+
+	// Standard SSH port is 22, but some containers might use different ports
+	// This could be made configurable per node type
+	containerPort := 22
+
+	// Create SSH session
+	session, err := sshManager.CreateSession(
+		username,
+		labName,
+		nodeName,
+		sshUsername,
+		containerIP,
+		containerPort,
+		duration,
+	)
+
+	if err != nil {
+		log.Errorf("SSH Access failed for user '%s': Failed to create SSH session: %v", username, err)
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{Error: "Failed to create SSH access: " + err.Error()})
+		return
+	}
+
+	// Get API server host
+	apiServerHost := getAPIServerHost(c.Request)
+
+	// Build response
+	response := models.SSHAccessResponse{
+		Port:       session.Port,
+		Host:       apiServerHost,
+		Username:   sshUsername,
+		Expiration: session.Expiration,
+		Command:    fmt.Sprintf("ssh -p %d %s@%s", session.Port, sshUsername, apiServerHost),
+	}
+
+	log.Infof("SSH access granted for user '%s' to lab '%s', node '%s' on port %d until %s",
+		username, labName, nodeName, session.Port, session.Expiration.Format(time.RFC3339))
+
+	c.JSON(http.StatusOK, response)
+}
+
+// @Summary List SSH Sessions
+// @Description Lists all active SSH sessions for the authenticated user
+// @Tags SSH Access
+// @Security BearerAuth
+// @Produce json
+// @Success 200 {array} models.SSHSessionInfo "List of active SSH sessions"
+// @Failure 401 {object} models.ErrorResponse "Unauthorized"
+// @Router /api/v1/ssh/sessions [get]
+func ListSSHSessionsHandler(c *gin.Context) {
+	username := c.GetString("username")
+	isSuperuser := isSuperuser(username)
+
+	sessions := sshManager.ListSessions(username, isSuperuser)
+
+	c.JSON(http.StatusOK, sessions)
+}
+
+// @Summary Terminate SSH Session
+// @Description Terminates a specific SSH session by port
+// @Tags SSH Access
+// @Security BearerAuth
+// @Produce json
+// @Param port path int true "SSH session port to terminate" example="2222"
+// @Success 200 {object} models.GenericSuccessResponse "Session terminated successfully"
+// @Failure 400 {object} models.ErrorResponse "Invalid port parameter"
+// @Failure 401 {object} models.ErrorResponse "Unauthorized"
+// @Failure 403 {object} models.ErrorResponse "Forbidden (not owner of the session)"
+// @Failure 404 {object} models.ErrorResponse "Session not found"
+// @Failure 500 {object} models.ErrorResponse "Internal server error"
+// @Router /api/v1/ssh/sessions/{port} [delete]
+func TerminateSSHSessionHandler(c *gin.Context) {
+	username := c.GetString("username")
+
+	port, err := strconv.Atoi(c.Param("port"))
+	if err != nil {
+		log.Warnf("Terminate SSH session failed for user '%s': Invalid port '%s'", username, c.Param("port"))
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "Invalid port parameter."})
+		return
+	}
+
+	// Get session
+	session, exists := sshManager.GetSession(port)
+	if !exists {
+		log.Warnf("Terminate SSH session failed for user '%s': Session on port %d not found", username, port)
+		c.JSON(http.StatusNotFound, models.ErrorResponse{Error: "SSH session not found."})
+		return
+	}
+
+	// Check ownership
+	if session.ApiUsername != username && !isSuperuser(username) {
+		log.Warnf("Terminate SSH session failed for user '%s': Attempted to terminate session owned by '%s'",
+			username, session.ApiUsername)
+		c.JSON(http.StatusForbidden, models.ErrorResponse{Error: "You don't have permission to terminate this SSH session."})
+		return
+	}
+
+	// Terminate session
+	err = sshManager.TerminateSession(port)
+	if err != nil {
+		log.Errorf("Terminate SSH session failed for user '%s', port %d: %v", username, port, err)
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{Error: "Failed to terminate SSH session: " + err.Error()})
+		return
+	}
+
+	log.Infof("SSH session on port %d terminated by user '%s'", port, username)
+	c.JSON(http.StatusOK, models.GenericSuccessResponse{Message: "SSH session terminated successfully."})
+}
+
+// Helper function to get API server host, respecting proxies and headers
+func getAPIServerHost(r *http.Request) string {
+	// Try X-Forwarded-Host header first (common with proxies)
+	forwardedHost := r.Header.Get("X-Forwarded-Host")
+	if forwardedHost != "" {
+		return forwardedHost
+	}
+
+	// Fall back to Host header
+	host := r.Host
+
+	// If Host includes a port and we're using HTTP/HTTPS standard ports, remove it
+	if strings.Contains(host, ":") {
+		// Remove port if it's a standard port
+		hostParts := strings.Split(host, ":")
+		if len(hostParts) == 2 {
+			if r.TLS != nil && hostParts[1] == "443" {
+				// HTTPS on standard port
+				return hostParts[0]
+			} else if r.TLS == nil && hostParts[1] == "80" {
+				// HTTP on standard port
+				return hostParts[0]
+			}
+		}
+	}
+
+	return host
+}
+
+// Helper function for validating node names
+func isValidNodeName(name string) bool {
+	if name == "" || len(name) > 128 {
+		return false
+	}
+
+	// Similar to labNameRegex but might be different for your specific needs
+	return labNameRegex.MatchString(name)
+}

--- a/internal/api/tools_handlers.go
+++ b/internal/api/tools_handlers.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/user" // <-- Ensure os/user is imported
+	"os/user"
 	"path/filepath"
-	"strconv" // <-- Ensure strconv is imported
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/log"
@@ -16,8 +16,6 @@ import (
 
 	"github.com/srl-labs/clab-api-server/internal/clab"
 	"github.com/srl-labs/clab-api-server/internal/models"
-	// "github.com/srl-labs/clab-api-server/internal/auth" // Already imported via helpers
-	// "github.com/srl-labs/clab-api-server/internal/config" // Already imported via helpers
 )
 
 // --- TX Offload Handler ---
@@ -59,8 +57,6 @@ func DisableTxOffloadHandler(c *gin.Context) {
 		return
 	}
 
-	// Optional: Verify container exists (using the less efficient inspect --all method for now)
-	// If performance is critical, direct runtime calls might be better.
 	_, err := verifyContainerOwnership(c, username, req.ContainerName) // We check ownership even for superuser to ensure container exists
 	if err != nil {
 		// verifyContainerOwnership already sent the response (404 or 500)
@@ -140,8 +136,6 @@ func CreateCAHandler(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "Invalid expiry duration format."})
 		return
 	}
-
-	// Other fields use clab defaults if empty
 
 	// --- Path Handling & Ownership Setup ---
 	basePath, err := getUserCertBasePath(username) // Get ~/.clab/certs path

--- a/internal/api/topology_handlers.go
+++ b/internal/api/topology_handlers.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/user" // Import os/user
+	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -61,7 +61,6 @@ func GenerateTopologyHandler(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "'images' field is required."})
 		return
 	}
-	// Add more validation for tier contents, image/license formats if needed
 
 	log.Debugf("GenerateTopology user '%s': Generating topology '%s' (deploy=%t)", username, req.Name, req.Deploy)
 
@@ -98,7 +97,6 @@ func GenerateTopologyHandler(c *gin.Context) {
 				nodeStr += ":" + tier.Type
 			}
 		} else if tier.Type != "" {
-			// If kind is empty but type is not, clab might need kind explicitly. Assume default.
 			defaultKind := req.DefaultKind
 			if defaultKind == "" {
 				defaultKind = "srl" // clab's default
@@ -121,8 +119,6 @@ func GenerateTopologyHandler(c *gin.Context) {
 	if len(req.Licenses) > 0 {
 		var licArgs []string
 		for kind, lic := range req.Licenses {
-			// Security: Ensure license path is somewhat sane? Difficult without knowing server layout.
-			// Rely on clab's own handling for now. Basic sanitization might be good.
 			cleanLic, licErr := clab.SanitizePath(lic) // Apply basic sanitization
 			if licErr != nil {
 				log.Warnf("GenerateTopology failed for user '%s': Invalid license path '%s': %v", username, lic, licErr)
@@ -148,8 +144,6 @@ func GenerateTopologyHandler(c *gin.Context) {
 	if req.IPv6Subnet != "" {
 		args = append(args, "--ipv6-subnet", req.IPv6Subnet)
 	}
-	// MaxWorkers is handled during deploy step if needed
-	// Deploy and OutputFile flags are handled specially below
 
 	// --- Determine Output/Action and Target File Path ---
 	var targetFilePath string // Path used by clab generate --file and clab deploy -t
@@ -199,8 +193,6 @@ func GenerateTopologyHandler(c *gin.Context) {
 		if err != nil {
 			// Log error but continue, maybe file write will succeed anyway if API user has perms
 			log.Warnf("GenerateTopology user '%s': Failed to set ownership on lab directory '%s': %v. Continuing...", username, targetDir, err)
-			// c.JSON(http.StatusInternalServerError, models.ErrorResponse{Error: fmt.Sprintf("Failed to set ownership on lab directory: %s.", err.Error())})
-			// return
 		}
 		log.Infof("GenerateTopology user '%s': Ensured directory '%s' exists and attempted ownership set.", username, targetDir)
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/srl-labs/clab-api-server/internal/config" // Adjust import path
+	"github.com/srl-labs/clab-api-server/internal/config"
 )
 
 type Claims struct {

--- a/internal/auth/credentials.go
+++ b/internal/auth/credentials.go
@@ -8,7 +8,7 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/msteinert/pam"
 
-	"github.com/srl-labs/clab-api-server/internal/config" // Ensure config is imported
+	"github.com/srl-labs/clab-api-server/internal/config"
 )
 
 // Define the primary required group name as a constant
@@ -111,10 +111,6 @@ func ValidateCredentials(username, password string) (bool, error) {
 	err = t.AcctMgmt(0)
 	if err != nil {
 		log.Warnf("PAM account management check failed for user '%s' (but login allowed as Authenticate and Group Check passed): %v", username, err)
-		// Decide if this should prevent login. For now, treat it as a warning
-		// and allow login if Authenticate and Group Check succeeded.
-		// You might return false here for stricter checks:
-		// return false, fmt.Errorf("PAM account validation failed: %w", err)
 	}
 
 	// 5. Success: Authenticated AND in one of the required login groups

--- a/internal/clab/executor.go
+++ b/internal/clab/executor.go
@@ -19,7 +19,6 @@ const defaultTimeout = 5 * time.Minute // Timeout for clab commands
 
 // RunClabCommand executes a clab command directly as the user running the API server.
 func RunClabCommand(ctx context.Context, username string, args ...string) (stdout string, stderr string, err error) {
-	// Add timeout to context if not already present
 	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, defaultTimeout)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	TLSKeyFile           string        `mapstructure:"TLS_KEY_FILE"`
 	GinMode              string        `mapstructure:"GIN_MODE"`
 	TrustedProxies       string        `mapstructure:"TRUSTED_PROXIES"`
+	APIServerHost        string        `mapstructure:"API_SERVER_HOST"` // Host/IP/FQDN used for SSH access commands
 }
 
 var AppConfig Config
@@ -44,6 +45,7 @@ func LoadConfig(envFilePath string) error {
 	viper.SetDefault("TLS_KEY_FILE", "")
 	viper.SetDefault("GIN_MODE", "debug")
 	viper.SetDefault("TRUSTED_PROXIES", "")
+	viper.SetDefault("API_SERVER_HOST", "")
 
 	err := viper.ReadInConfig()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,8 @@ type Config struct {
 	GinMode              string        `mapstructure:"GIN_MODE"`
 	TrustedProxies       string        `mapstructure:"TRUSTED_PROXIES"`
 	APIServerHost        string        `mapstructure:"API_SERVER_HOST"` // Host/IP/FQDN used for SSH access commands
+	SSHBasePort          int           `mapstructure:"SSH_BASE_PORT"`   // Base port for SSH proxy allocation
+	SSHMaxPort           int           `mapstructure:"SSH_MAX_PORT"`    // Maximum port for SSH proxy allocation
 }
 
 var AppConfig Config
@@ -46,6 +48,8 @@ func LoadConfig(envFilePath string) error {
 	viper.SetDefault("GIN_MODE", "debug")
 	viper.SetDefault("TRUSTED_PROXIES", "")
 	viper.SetDefault("API_SERVER_HOST", "")
+	viper.SetDefault("SSH_BASE_PORT", 2222) // Default base port for SSH proxy
+	viper.SetDefault("SSH_MAX_PORT", 2322)  // Default max port for SSH proxy (allows 100 sessions)
 
 	err := viper.ReadInConfig()
 

--- a/internal/models/ssh_models.go
+++ b/internal/models/ssh_models.go
@@ -1,0 +1,29 @@
+// internal/models/ssh_models.go
+package models
+
+import "time"
+
+// SSHAccessRequest represents the payload for requesting SSH access to a node
+type SSHAccessRequest struct {
+	SSHUsername string `json:"sshUsername,omitempty"` // Optional override for container's SSH user
+	Duration    string `json:"duration,omitempty"`    // How long the access should be valid for (e.g., "1h", "30m")
+}
+
+// SSHAccessResponse represents the response with SSH connection details
+type SSHAccessResponse struct {
+	Port       int       `json:"port"`       // Allocated port on API server
+	Host       string    `json:"host"`       // API server's hostname or IP
+	Username   string    `json:"username"`   // Username to use for SSH
+	Expiration time.Time `json:"expiration"` // When this access expires
+	Command    string    `json:"command"`    // Example SSH command
+}
+
+// SSHSessionInfo represents information about an active SSH session
+type SSHSessionInfo struct {
+	Port       int       `json:"port"`       // Allocated port on API server
+	LabName    string    `json:"labName"`    // Lab name
+	NodeName   string    `json:"nodeName"`   // Node name
+	Username   string    `json:"username"`   // SSH username
+	Expiration time.Time `json:"expiration"` // When this access expires
+	Created    time.Time `json:"created"`    // When this access was created
+}

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -1,0 +1,383 @@
+// internal/ssh/manager.go
+package ssh
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/charmbracelet/log"
+	"github.com/srl-labs/clab-api-server/internal/models"
+)
+
+// Configuration constants for SSH proxy service
+const (
+	DefaultSSHBasePort       = 2222           // Starting port for SSH proxy allocation
+	DefaultSSHMaxPort        = 2322           // Maximum port (allows 100 concurrent sessions)
+	DefaultSSHCleanupTick    = time.Minute    // Cleanup interval for expired sessions
+	DefaultSSHSessionTimeout = time.Hour      // Default session duration if not specified
+	MaxSSHSessionDuration    = 24 * time.Hour // Maximum allowed session duration
+)
+
+// SSHSession represents an active SSH proxy session
+type SSHSession struct {
+	Port        int       // Allocated port on API server
+	LabName     string    // Name of the lab
+	NodeName    string    // Name of the node within the lab
+	Username    string    // SSH username to use
+	ApiUsername string    // API user who created this session
+	Expiration  time.Time // When this session expires
+	Created     time.Time // When this session was created
+	cmd         *exec.Cmd // Proxy process
+	cmdCancel   func()    // Function to cancel the proxy process
+}
+
+// SSHManager handles SSH session creation, management, and cleanup
+type SSHManager struct {
+	mu              sync.Mutex
+	sessions        map[int]*SSHSession
+	basePort        int
+	maxPort         int
+	cleanupTick     time.Duration
+	defaultDuration time.Duration
+	shutdownCh      chan struct{}
+}
+
+// NewSSHManager creates a new SSH manager with the given configuration
+func NewSSHManager(basePort, maxPort int, cleanupTick, defaultDuration time.Duration) *SSHManager {
+	if basePort <= 0 {
+		basePort = DefaultSSHBasePort
+	}
+	if maxPort <= basePort {
+		maxPort = basePort + 100 // Ensure at least some ports are available
+	}
+	if cleanupTick <= 0 {
+		cleanupTick = DefaultSSHCleanupTick
+	}
+	if defaultDuration <= 0 {
+		defaultDuration = DefaultSSHSessionTimeout
+	}
+
+	m := &SSHManager{
+		sessions:        make(map[int]*SSHSession),
+		basePort:        basePort,
+		maxPort:         maxPort,
+		cleanupTick:     cleanupTick,
+		defaultDuration: defaultDuration,
+		shutdownCh:      make(chan struct{}),
+	}
+
+	// Start background cleanup
+	go m.cleanupRoutine()
+
+	log.Info("SSH Manager initialized",
+		"basePort", basePort,
+		"maxPort", maxPort,
+		"cleanupInterval", cleanupTick.String(),
+		"defaultDuration", defaultDuration.String())
+
+	return m
+}
+
+// CreateSession creates a new SSH proxy session for the specified lab node
+func (m *SSHManager) CreateSession(apiUsername, labName, nodeName, sshUsername string,
+	containerIP string, containerPort int, duration time.Duration) (*SSHSession, error) {
+
+	if duration > MaxSSHSessionDuration {
+		duration = MaxSSHSessionDuration
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Allocate port
+	port, err := m.allocatePort()
+	if err != nil {
+		return nil, fmt.Errorf("failed to allocate port: %w", err)
+	}
+
+	// Create session
+	now := time.Now()
+	session := &SSHSession{
+		Port:        port,
+		LabName:     labName,
+		NodeName:    nodeName,
+		Username:    sshUsername,
+		ApiUsername: apiUsername,
+		Created:     now,
+		Expiration:  now.Add(duration),
+	}
+
+	// Start proxy
+	err = m.startProxy(session, containerIP, containerPort)
+	if err != nil {
+		// Free the port if proxy fails to start
+		m.sessions[port] = nil
+		return nil, fmt.Errorf("failed to start SSH proxy: %w", err)
+	}
+
+	// Store session
+	m.sessions[port] = session
+
+	log.Info("SSH session created",
+		"user", apiUsername,
+		"lab", labName,
+		"node", nodeName,
+		"port", port,
+		"expiration", session.Expiration.Format(time.RFC3339))
+
+	return session, nil
+}
+
+// GetSession retrieves a session by port
+func (m *SSHManager) GetSession(port int) (*SSHSession, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	session, exists := m.sessions[port]
+	if !exists || session == nil {
+		return nil, false
+	}
+	return session, true
+}
+
+// ListSessions returns all sessions for the specified user
+// If isSuperuser is true, all sessions are returned
+func (m *SSHManager) ListSessions(username string, isSuperuser bool) []models.SSHSessionInfo {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Initialize as an empty slice, NOT a nil slice
+	result := make([]models.SSHSessionInfo, 0) // <--- CHANGE THIS LINE
+
+	// Add logging to see map content (optional, for debugging)
+	log.Debugf("Listing SSH sessions. Current map size: %d", len(m.sessions))
+
+	for port, session := range m.sessions {
+		if session == nil {
+			log.Debugf("Skipping nil session entry for port %d", port)
+			continue
+		}
+
+		// Add logging for filtering logic (optional, for debugging)
+		log.Debugf("Checking session on port %d: ApiUsername=%s, targetUsername=%s, isSuperuser=%t",
+			port, session.ApiUsername, username, isSuperuser)
+
+		if isSuperuser || session.ApiUsername == username {
+			result = append(result, models.SSHSessionInfo{
+				Port:       session.Port,
+				LabName:    session.LabName,
+				NodeName:   session.NodeName,
+				Username:   session.Username,
+				Expiration: session.Expiration,
+				Created:    session.Created,
+			})
+			log.Debugf("Added session on port %d to results.", port)
+		}
+	}
+
+	// Add logging to see the final result before returning (optional, for debugging)
+	log.Debugf("Returning %d SSH sessions.", len(result))
+
+	return result
+}
+
+// TerminateSession terminates a specific SSH session
+func (m *SSHManager) TerminateSession(port int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	session, exists := m.sessions[port]
+	if !exists || session == nil {
+		return fmt.Errorf("session not found")
+	}
+
+	// Terminate proxy
+	if session.cmdCancel != nil {
+		session.cmdCancel()
+	}
+
+	// Remove session
+	delete(m.sessions, port)
+
+	log.Info("SSH session terminated", "port", port, "lab", session.LabName, "node", session.NodeName)
+	return nil
+}
+
+// Shutdown terminates all sessions and stops the manager
+func (m *SSHManager) Shutdown() {
+	close(m.shutdownCh)
+
+	// Terminate all sessions
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for port, session := range m.sessions {
+		if session != nil && session.cmdCancel != nil {
+			session.cmdCancel()
+		}
+		delete(m.sessions, port)
+	}
+
+	log.Info("SSH Manager shutdown complete")
+}
+
+// allocatePort finds and allocates an available port
+func (m *SSHManager) allocatePort() (int, error) {
+	// Try each port in the range
+	for port := m.basePort; port <= m.maxPort; port++ {
+		// Skip if port is already in use by another session
+		if _, exists := m.sessions[port]; exists {
+			continue
+		}
+
+		// Test if port is available on the system
+		addr := fmt.Sprintf(":%d", port)
+		ln, err := net.Listen("tcp", addr)
+		if err != nil {
+			// Port is in use by another process
+			continue
+		}
+		ln.Close()
+
+		// Reserve this port by creating a nil entry
+		m.sessions[port] = nil
+		return port, nil
+	}
+
+	return 0, fmt.Errorf("no available ports in range %d-%d", m.basePort, m.maxPort)
+}
+
+// startProxy starts a proxy process for the given session
+func (m *SSHManager) startProxy(session *SSHSession, containerIP string, containerPort int) error {
+	// We'll use a TCP proxy in Go instead of relying on external tools like socat
+	go func() {
+		localAddr := fmt.Sprintf("0.0.0.0:%d", session.Port)
+		remoteAddr := fmt.Sprintf("%s:%d", containerIP, containerPort)
+
+		log.Debug("Starting TCP proxy",
+			"localAddr", localAddr,
+			"remoteAddr", remoteAddr,
+			"session", session.Port)
+
+		listener, err := net.Listen("tcp", localAddr)
+		if err != nil {
+			log.Error("Failed to listen on proxy port",
+				"port", session.Port,
+				"error", err)
+			return
+		}
+		defer listener.Close()
+
+		// Create a context with cancel function for termination
+		ctx, cancel := context.WithCancel(context.Background())
+		session.cmdCancel = cancel
+
+		// Run the proxy until canceled or expired
+		go func() {
+			select {
+			case <-ctx.Done():
+				listener.Close()
+			case <-time.After(session.Expiration.Sub(time.Now())):
+				// Session expired
+				listener.Close()
+				m.TerminateSession(session.Port)
+			}
+		}()
+
+		for {
+			client, err := listener.Accept()
+			if err != nil {
+				// Check if this is due to listener being closed
+				if ne, ok := err.(net.Error); ok && ne.Temporary() {
+					continue
+				}
+				return
+			}
+
+			go handleConnection(client, remoteAddr)
+		}
+	}()
+
+	return nil
+}
+
+// handleConnection manages a single proxied connection
+func handleConnection(client net.Conn, remoteAddr string) {
+	defer client.Close()
+
+	remote, err := net.Dial("tcp", remoteAddr)
+	if err != nil {
+		log.Error("Failed to connect to remote address",
+			"remoteAddr", remoteAddr,
+			"error", err)
+		return
+	}
+	defer remote.Close()
+
+	// Copy bidirectionally
+	errCh := make(chan error, 2)
+
+	// client -> remote
+	go func() {
+		_, err := io.Copy(remote, client)
+		errCh <- err
+	}()
+
+	// remote -> client
+	go func() {
+		_, err := io.Copy(client, remote)
+		errCh <- err
+	}()
+
+	// Wait for either direction to finish
+	<-errCh
+}
+
+// cleanupRoutine periodically removes expired sessions
+func (m *SSHManager) cleanupRoutine() {
+	ticker := time.NewTicker(m.cleanupTick)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			m.cleanupExpiredSessions()
+		case <-m.shutdownCh:
+			return
+		}
+	}
+}
+
+// cleanupExpiredSessions removes all expired sessions
+func (m *SSHManager) cleanupExpiredSessions() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	for port, session := range m.sessions {
+		if session == nil {
+			// This is a reserved port without a session, clean it up
+			delete(m.sessions, port)
+			continue
+		}
+
+		if now.After(session.Expiration) {
+			// Terminate the proxy
+			if session.cmdCancel != nil {
+				session.cmdCancel()
+			}
+
+			// Remove the session
+			delete(m.sessions, port)
+			log.Info("Expired SSH session cleaned up",
+				"port", port,
+				"lab", session.LabName,
+				"node", session.NodeName)
+		}
+	}
+}


### PR DESCRIPTION
The API server provides SSH proxy functionality, allowing you to connect to lab nodes without direct access to the container network.
How it works

The API server creates a TCP proxy on a dynamically allocated port
The proxy forwards connections to the target node's SSH port
You connect to the API server's allocated port using your regular SSH client
Sessions have configurable timeouts and are automatically cleaned up


```
httpPOST /api/v1/labs/{labName}/nodes/{nodeName}/ssh
Content-Type: application/json

{
  "sshUsername": "admin",
  "duration": "1h"
}
```

```
{
  "port": 2222,
  "host": "api-server.example.com",
  "username": "admin",
  "expiration": "2025-04-18T12:00:00Z",
  "command": "ssh -p 2222 admin@api-server.example.com"
}
```