### PR TITLE
fix default vxlan port in documentation

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2985,6 +2985,10 @@ const docTemplate = `{
                     "description": "How long the access should be valid for (e.g., \"1h\", \"30m\")",
                     "type": "string"
                 },
+                "port": {
+                    "description": "Which internal node port shoul be open",
+                    "type": "integer"
+                },
                 "sshUsername": {
                     "description": "Optional override for container's SSH user",
                     "type": "string"
@@ -3234,7 +3238,7 @@ const docTemplate = `{
                     "example": 1400
                 },
                 "port": {
-                    "description": "UDP port number for the VxLAN tunnel. Defaults to 4789 if omitted.",
+                    "description": "UDP port number for the VxLAN tunnel. Defaults to 14789 if omitted.",
                     "type": "integer",
                     "example": 4789
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2981,6 +2981,10 @@
                     "description": "How long the access should be valid for (e.g., \"1h\", \"30m\")",
                     "type": "string"
                 },
+                "port": {
+                    "description": "Which internal node port shoul be open",
+                    "type": "integer"
+                },
                 "sshUsername": {
                     "description": "Optional override for container's SSH user",
                     "type": "string"
@@ -3230,7 +3234,7 @@
                     "example": 1400
                 },
                 "port": {
-                    "description": "UDP port number for the VxLAN tunnel. Defaults to 4789 if omitted.",
+                    "description": "UDP port number for the VxLAN tunnel. Defaults to 14789 if omitted.",
                     "type": "integer",
                     "example": 4789
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -520,6 +520,9 @@ definitions:
       duration:
         description: How long the access should be valid for (e.g., "1h", "30m")
         type: string
+      port:
+        description: Which internal node port shoul be open
+        type: integer
       sshUsername:
         description: Optional override for container's SSH user
         type: string
@@ -706,7 +709,7 @@ definitions:
         example: 1400
         type: integer
       port:
-        description: UDP port number for the VxLAN tunnel. Defaults to 4789 if omitted.
+        description: UDP port number for the VxLAN tunnel. Defaults to 14789 if omitted.
         example: 4789
         type: integer
       remote:

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -270,7 +270,7 @@ type VxlanCreateRequest struct {
 	// VxLAN Network Identifier (VNI). Defaults to 10 if omitted.
 	ID int `json:"id,omitempty" example:"100"`
 
-	// UDP port number for the VxLAN tunnel. Defaults to 4789 if omitted.
+	// UDP port number for the VxLAN tunnel. Defaults to 14789 if omitted.
 	Port int `json:"port,omitempty" example:"4789"` // Default is 4789 (IANA standard)
 
 	// Optional: Linux device to use for the tunnel source. Auto-detected if omitted.


### PR DESCRIPTION
According to containerlab tools documentation default port for vxlan is 14879
<img width="582" alt="Screenshot 2025-05-26 at 14 24 46" src="https://github.com/user-attachments/assets/a9c6dd21-7d4c-4554-ba04-ce91292ff0ac" />

After the /api/v1/tools/vxlan call, we can see the result
<img width="869" alt="Screenshot 2025-05-26 at 14 40 32" src="https://github.com/user-attachments/assets/17a9186b-008a-45d9-b699-07800bf06fa4" />
