### PR TITLE
fix #41 update originalTopoPath to use AbsLabPath instead of LabPath

### DIFF
--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -271,7 +271,7 @@ func verifyLabOwnership(c *gin.Context, username, labName string) (string, error
 
 	// Lab exists, now check ownership
 	actualOwner := labInfo.Owner
-	originalTopoPath := labInfo.LabPath // Use LabPath (relative) or AbsLabPath? LabPath is what clab usually needs.
+	originalTopoPath := labInfo.AbsLabPath // Using AbsLabPath as LabPath (relative) does not delete lab dir on cleanup
 
 	// Check superuser status or direct ownership
 	if isSuperuser(username) {


### PR DESCRIPTION
Suggested fix for issue #41 

suggested change

```shell
--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -271,7 +271,7 @@ func verifyLabOwnership(c *gin.Context, username, labName string) (string, error

 	// Lab exists, now check ownership
 	actualOwner := labInfo.Owner
-	originalTopoPath := labInfo.LabPath // Use LabPath (relative) or AbsLabPath? LabPath is what clab usually needs.
+	originalTopoPath := labInfo.AbsLabPath // Using AbsLabPath as LabPath (relative) does not delete lab dir on cleanup

 	// Check superuser status or direct ownership
 	if isSuperuser(username) {
```

tested to work with dev build

```shell
DEBU getLabInfo: Lab 'clab-1' found. Owner: 'johndoe'.
DEBU Group check: User 'johndoe' is a member of group 'clab_admins' (GID: xxx).
INFO Ownership check bypass for user 'johndoe' on lab 'clab-1': User is superuser.
DEBU Superuser 'johndoe' accessing lab 'clab-1' (Owner: 'johndoe', Original Path: '/home/johndoe/.clab/clab-1/clab-1.clab.yml').
INFO DestroyLab user 'johndoe': Executing clab destroy for lab 'clab-1' (cleanup=true)...
DEBU Using default container runtime runtime=docker
DEBU Executing command triggered_by_user=johndoe runtime=docker command="containerlab destroy --name clab-1" cwd=/home/johndoe/.clab
DEBU Command successful triggered_by_user=johndoe duration=1.623981797s stdout_len=0 stderr_len=415
INFO Lab 'clab-1' destroyed successfully via clab for user 'johndoe'.
WARN DestroyLab user 'johndoe': clab destroy stderr for lab 'clab-1' (command succeeded): INFO Parsing & checking topology file=clab-1.clab.yml
INFO Parsing & checking topology file=clab-1.clab.yml
INFO Destroying lab name=clab-1

INFO DestroyLab user 'johndoe': Cleanup requested. Removing directory: /home/johndoe/.clab/clab-1
INFO Successfully cleaned up topology directory '/home/johndoe/.clab/clab-1' for user 'johndoe'
```