### PR TITLE
chore(ci): bump workflow GitHub Actions major versions

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Upload HTML test report
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: go-test-report
           path: test-reports/test-report.html

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,13 +119,13 @@ jobs:
     # Docker Buildx Setup and Login
     #---------------------------------------------------------------
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
     - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -136,7 +136,7 @@ jobs:
     #---------------------------------------------------------------
     - name: Extract Docker metadata for simple-container
       id: meta_simple
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: ghcr.io/${{ env.REPO_LOWER }}/clab-api-server # Use lowercase repo name
         tags: |
@@ -148,7 +148,7 @@ jobs:
     # Build and push simple-container multi-arch image
     #---------------------------------------------------------------
     - name: Build and push simple-container
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: . # Build context is the repo root
         file: ./docker/simple-container/Dockerfile # Path to the Dockerfile


### PR DESCRIPTION
## Summary
- bump `docker/setup-qemu-action` from `v3` to `v4`
- bump `docker/login-action` from `v3` to `v4`
- bump `docker/metadata-action` from `v5` to `v6`
- bump `docker/build-push-action` from `v6` to `v7`
- bump `actions/upload-artifact` from `v6` to `v7`

## Validation
- local build succeeded: `go build -ldflags="-X main.version=... -X main.commit=... -X main.date=..." -o dist/clab-api-server-linux-amd64 ./cmd/server`

## Notes
- this intentionally updates workflow files directly instead of merging existing Dependabot PRs
