### PR TITLE
fix: install compose plugin in simple-container image

### DIFF
--- a/docker/simple-container/Dockerfile
+++ b/docker/simple-container/Dockerfile
@@ -30,6 +30,7 @@ RUN echo \
   tee /etc/apt/sources.list.d/docker.list > /dev/null
 RUN apt-get update && apt-get install -y --no-install-recommends \
     docker-ce-cli \
+    docker-compose-plugin \
  && rm -rf /var/lib/apt/lists/*
 
 # User setup


### PR DESCRIPTION
# fix: install compose plugin in simple-container image

The simple-container image only installs `docker-ce-cli`, so the web UI
Edgeshark install fails in the container without the compose plugin.

Error message:

```text
failed to install edgeshark: exit status 125: unknown shorthand flag: 'f' in -f

Usage:  docker [OPTIONS] COMMAND [ARG...]

Run 'docker --help' for more information
```

## Changes

- add `docker-compose-plugin` to the simple-container image

## Relevant code and history

- code: `internal/capture/manager.go:277`
- from commit: `ce80d851` in PR #97

## Tests for this PR

1. I built a local image with this small change and tested the official `latest` image vs. my `local` image
2. `latest` image: Edgeshark `install` and `uninstall` both failed with same error
3. `local` image: Edgeshark `install` and `uninstall` both work

### Build local image commands

These were my commands to build the local image:

```shell
cd ../clab-api-server
sudo dnf install pam-devel
mkdir -p dist
GOOS=linux GOARCH=amd64 go build -trimpath -o dist/clab-api-server-linux-amd64 ./cmd/server
docker buildx build \
  --platform linux/amd64 \
  --load \
  -t clab-api-server:local \
  -f ./docker/simple-container/Dockerfile \
  .
```
