### PR TITLE
Stream lifecycle output from the apply endpoint

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1623,7 +1623,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Applies an on-disk topology from the authenticated user's lab directory. If the lab is not running, containerlab apply deploys it; otherwise it reconciles supported topology changes in place.\n\n**Notes**\n- ` + "`" + `path` + "`" + ` defaults to the running lab topology path when the lab exists, otherwise ` + "`" + `\u003clabName\u003e.clab.yml` + "`" + `.\n- ` + "`" + `dryRun=true` + "`" + ` returns the apply plan without changing the lab.\n- ` + "`" + `includeLogs=true` + "`" + ` includes captured lifecycle logs in the JSON response.",
+                "description": "Applies an on-disk topology from the authenticated user's lab directory. If the lab is not running, containerlab apply deploys it; otherwise it reconciles supported topology changes in place.\n\n**Notes**\n- ` + "`" + `path` + "`" + ` defaults to the running lab topology path when the lab exists, otherwise ` + "`" + `\u003clabName\u003e.clab.yml` + "`" + `.\n- ` + "`" + `dryRun=true` + "`" + ` returns the apply plan without changing the lab.\n- ` + "`" + `stream=true` + "`" + ` returns ` + "`" + `application/x-ndjson` + "`" + ` lifecycle events.\n- ` + "`" + `includeLogs=true` + "`" + ` includes captured lifecycle logs in the JSON response.",
                 "produces": [
                     "application/json"
                 ],
@@ -1667,6 +1667,12 @@ const docTemplate = `{
                         "type": "boolean",
                         "description": "Skip post-deploy actions for added nodes",
                         "name": "skipPostDeploy",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Stream lifecycle output as NDJSON events",
+                        "name": "stream",
                         "in": "query"
                     },
                     {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1619,7 +1619,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Applies an on-disk topology from the authenticated user's lab directory. If the lab is not running, containerlab apply deploys it; otherwise it reconciles supported topology changes in place.\n\n**Notes**\n- `path` defaults to the running lab topology path when the lab exists, otherwise `\u003clabName\u003e.clab.yml`.\n- `dryRun=true` returns the apply plan without changing the lab.\n- `includeLogs=true` includes captured lifecycle logs in the JSON response.",
+                "description": "Applies an on-disk topology from the authenticated user's lab directory. If the lab is not running, containerlab apply deploys it; otherwise it reconciles supported topology changes in place.\n\n**Notes**\n- `path` defaults to the running lab topology path when the lab exists, otherwise `\u003clabName\u003e.clab.yml`.\n- `dryRun=true` returns the apply plan without changing the lab.\n- `stream=true` returns `application/x-ndjson` lifecycle events.\n- `includeLogs=true` includes captured lifecycle logs in the JSON response.",
                 "produces": [
                     "application/json"
                 ],
@@ -1663,6 +1663,12 @@
                         "type": "boolean",
                         "description": "Skip post-deploy actions for added nodes",
                         "name": "skipPostDeploy",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Stream lifecycle output as NDJSON events",
+                        "name": "stream",
                         "in": "query"
                     },
                     {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2037,6 +2037,7 @@ paths:
         **Notes**
         - `path` defaults to the running lab topology path when the lab exists, otherwise `<labName>.clab.yml`.
         - `dryRun=true` returns the apply plan without changing the lab.
+        - `stream=true` returns `application/x-ndjson` lifecycle events.
         - `includeLogs=true` includes captured lifecycle logs in the JSON response.
       parameters:
       - description: Lab name
@@ -2064,6 +2065,10 @@ paths:
       - description: Skip post-deploy actions for added nodes
         in: query
         name: skipPostDeploy
+        type: boolean
+      - description: Stream lifecycle output as NDJSON events
+        in: query
+        name: stream
         type: boolean
       - description: Include captured lifecycle logs in the JSON response
         in: query

--- a/internal/api/lifecycle_apply_summary.go
+++ b/internal/api/lifecycle_apply_summary.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/srl-labs/clab-api-server/internal/models"
+)
+
+type applySummaryRow struct {
+	action string
+	detail string
+}
+
+func buildApplySummaryTableLines(result models.ApplyLabResponse) []string {
+	rows := collectApplySummaryRows(result)
+
+	actionWidth := 18
+	detailWidth := 48
+	for _, row := range rows {
+		if len(row.action)+2 > actionWidth {
+			actionWidth = len(row.action) + 2
+		}
+		if len(row.detail)+2 > detailWidth {
+			detailWidth = len(row.detail) + 2
+		}
+	}
+
+	top := "╭" + strings.Repeat("─", actionWidth) + "┬" + strings.Repeat("─", detailWidth) + "╮"
+	sep := "├" + strings.Repeat("─", actionWidth) + "┼" + strings.Repeat("─", detailWidth) + "┤"
+	bottom := "╰" + strings.Repeat("─", actionWidth) + "┴" + strings.Repeat("─", detailWidth) + "╯"
+
+	lines := []string{
+		top,
+		fmt.Sprintf("│%s│%s│", centerText("Action", actionWidth), centerText("Details", detailWidth)),
+		sep,
+	}
+	for _, row := range rows {
+		lines = append(lines, fmt.Sprintf(
+			"│ %s│ %s│",
+			padRight(truncate(row.action, actionWidth-2), actionWidth-1),
+			padRight(truncate(row.detail, detailWidth-2), detailWidth-1),
+		))
+	}
+	lines = append(lines, bottom)
+
+	return lines
+}
+
+func collectApplySummaryRows(result models.ApplyLabResponse) []applySummaryRow {
+	rows := make([]applySummaryRow, 0, 16)
+
+	if result.DeployedLab {
+		label := "deployed lab"
+		if result.DryRun {
+			label = "deploy lab"
+		}
+		rows = append(rows, applySummaryRow{action: label, detail: result.LabName})
+	}
+
+	appendRows := func(label string, values []string) {
+		for _, value := range values {
+			rows = append(rows, applySummaryRow{action: label, detail: value})
+		}
+	}
+
+	appendRows("added nodes", result.AddedNodes)
+	appendRows("deleted nodes", result.DeletedNodes)
+	appendRows("recreated nodes", withApplyChangeReasons(result.RecreatedNodes, result.NodeChangeReasons))
+	appendRows("started nodes", result.StartedNodes)
+	appendRows("added links", result.AddedLinks)
+	appendRows("deleted endpoints", result.DeletedEndpoints)
+	appendRows("restarted nodes", withApplyChangeReasons(result.RestartedNodes, result.NodeChangeReasons))
+
+	if len(rows) == 0 {
+		rows = append(rows, applySummaryRow{action: "no changes", detail: "-"})
+	}
+
+	return rows
+}
+
+func withApplyChangeReasons(nodeNames []string, reasons map[string]string) []string {
+	if len(reasons) == 0 {
+		return nodeNames
+	}
+
+	values := make([]string, 0, len(nodeNames))
+	for _, nodeName := range nodeNames {
+		if reason, ok := reasons[nodeName]; ok && strings.TrimSpace(reason) != "" {
+			values = append(values, fmt.Sprintf("%s (%s)", nodeName, reason))
+			continue
+		}
+		values = append(values, nodeName)
+	}
+
+	return values
+}

--- a/internal/api/topology_files_handlers.go
+++ b/internal/api/topology_files_handlers.go
@@ -576,6 +576,7 @@ func DeployTopologyHandler(c *gin.Context) {
 // @Description **Notes**
 // @Description - `path` defaults to the running lab topology path when the lab exists, otherwise `<labName>.clab.yml`.
 // @Description - `dryRun=true` returns the apply plan without changing the lab.
+// @Description - `stream=true` returns `application/x-ndjson` lifecycle events.
 // @Description - `includeLogs=true` includes captured lifecycle logs in the JSON response.
 // @Tags Labs
 // @Security BearerAuth
@@ -586,6 +587,7 @@ func DeployTopologyHandler(c *gin.Context) {
 // @Param maxWorkers query int false "Limit concurrent workers for new nodes"
 // @Param exportTemplate query string false "Custom Go template file for topology data export"
 // @Param skipPostDeploy query boolean false "Skip post-deploy actions for added nodes"
+// @Param stream query boolean false "Stream lifecycle output as NDJSON events"
 // @Param includeLogs query boolean false "Include captured lifecycle logs in the JSON response"
 // @Success 200 {object} models.ApplyLabResponse "Apply result"
 // @Failure 400 {object} models.ErrorResponse "Invalid input"
@@ -598,6 +600,7 @@ func DeployTopologyHandler(c *gin.Context) {
 func ApplyTopologyHandler(c *gin.Context) {
 	username := c.GetString("username")
 	labName := c.Param("labName")
+	streamLogs := c.Query("stream") == "true"
 	includeLogs := c.Query("includeLogs") == "true"
 	if !isValidLabName(labName) {
 		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "Invalid characters in lab name."})
@@ -702,6 +705,21 @@ func ApplyTopologyHandler(c *gin.Context) {
 			return models.ApplyLabResponse{}, fmt.Errorf("Failed to apply lab '%s': %s", labName, applyErr.Error())
 		}
 		return clab.ApplyResultToResponse(result), nil
+	}
+
+	if streamLogs {
+		var result models.ApplyLabResponse
+		streamLifecycleCommandWithOptions(c, func() error {
+			var runErr error
+			result, runErr = runApply()
+			return runErr
+		}, "", &lifecycleStreamOptions{
+			Preamble: buildDeployPreambleLines(),
+			OnSuccess: func() []string {
+				return buildApplySummaryTableLines(result)
+			},
+		})
+		return
 	}
 
 	if includeLogs {


### PR DESCRIPTION
## Summary

Adds `stream=true` NDJSON support to `POST /api/v1/labs/{labName}/apply`, matching the deploy/destroy/redeploy endpoints, so UIs can show live lifecycle logs while applying. On success the stream ends with an apply summary table (deployed lab / added / deleted / recreated / restarted entries with change reasons), mirroring the containerlab CLI output. Swagger docs regenerated.

This backs the Apply button in the containerlab-web UI (srl-labs/containerlab-web PR) which streams apply progress through `/api/lab/apply/stream`.

## Test evidence

- `go build ./...`, `go vet ./internal/api/`, `gofmt` clean
- `go test ./internal/...` passing

No file-based version to bump (releases are git tags); suggest tagging v0.5.0 once merged.