### PR TITLE
 bump API server workflows

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,9 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: github-pages
@@ -17,11 +15,8 @@ concurrency:
 
 jobs:
   deploy:
-    name: Deploy ReDoc to GitHub Pages
+    name: Publish ReDoc to gh-pages
     runs-on: ubuntu-24.04
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -36,14 +31,31 @@ jobs:
           cp docs/swagger.yaml public/swagger.yaml
           touch public/.nojekyll
 
-      - name: Configure Pages
-        uses: actions/configure-pages@v6
+      - name: Publish to gh-pages
+        run: |
+          set -euo pipefail
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: public
+          repo_dir="$PWD"
+          publish_dir="$(mktemp -d)"
+          cleanup() {
+            cd "$repo_dir"
+            git worktree remove --force "$publish_dir" >/dev/null 2>&1 || rm -rf "$publish_dir"
+          }
+          trap cleanup EXIT
 
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages --depth=1
+
+          git worktree add "$publish_dir" origin/gh-pages
+          cp -a public/. "$publish_dir"/
+
+          cd "$publish_dir"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No API docs changes to publish."
+            exit 0
+          fi
+
+          git commit -m "publish api docs"
+          git push origin HEAD:gh-pages

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: WillAbides/setup-go-faster@v1.19.0
         with:
-          go-version: "1.24.x"
+          go-version: "1.25.x"
 
       - name: Cache Go modules
         uses: actions/cache@v6
@@ -143,7 +143,7 @@ jobs:
       - name: Set up Go
         uses: WillAbides/setup-go-faster@v1.19.0
         with:
-          go-version: "1.24.x"
+          go-version: "1.25.x"
 
       - name: Cache Go modules
         uses: actions/cache@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Setup Go (fast)
       uses: WillAbides/setup-go-faster@v1.19.0
       with:
-        go-version: '1.24.x'
+        go-version: '1.25.x'
 
     #---------------------------------------------------------------
     # 4 — Fix mirrors, add arm64 repos, install cross tool‑chain


### PR DESCRIPTION
## What changed

- Update PR test workflows to install Go 1.25.x.
- Update the release workflow to install Go 1.25.x.
- Change API docs publishing to update the configured `gh-pages` branch directly instead of using the failing Pages artifact deployment API.

## Why

`go.mod` now requires Go 1.25.7, but GitHub Actions still installed Go 1.24.x. Aligning Actions with the module directive lets PR and release builds use the expected toolchain family.

The `Publish API Docs` workflow has also been failing on `main` at `actions/deploy-pages@v5` after creating a valid Pages artifact and deployment. The repository's Pages source is configured as the `gh-pages` branch, so publishing the prepared ReDoc assets there directly matches the current repo configuration and avoids the failing deployment path.

## Validation

- `go test ./internal/serverversion ./internal/api ./internal/config ./internal/clab ./internal/tlsconfig ./internal/auth ./internal/terminal ./internal/capture ./cmd/server`
- `go build -trimpath -o /tmp/clab-api-server ./cmd/server`
- `git diff --check`
- `yq e '.' .github/workflows/pages.yml`
- Dry-ran the `gh-pages` publish script locally without pushing; it updates only `.nojekyll`, `index.html`, `swagger.json`, and `swagger.yaml`.
