### PR TITLE
fix: update Wireshark VNC image registry

### DIFF
--- a/internal/capture/manager.go
+++ b/internal/capture/manager.go
@@ -145,7 +145,7 @@ func NewManager(cfg ManagerConfig) *Manager {
 		normalized.PacketflixPort = 5001
 	}
 	if normalized.WiresharkDockerImage == "" {
-		normalized.WiresharkDockerImage = "ghcr.io/kaelemc/wireshark-vnc-docker:latest"
+		normalized.WiresharkDockerImage = "ghcr.io/srl-labs/wireshark-vnc-docker:latest"
 	}
 	if normalized.WiresharkSessionTTL <= 0 {
 		normalized.WiresharkSessionTTL = 2 * time.Hour

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,7 +58,7 @@ func LoadConfig(envFilePath string) error {
 	viper.SetDefault("CLAB_LABS_ROOT", "")
 	viper.SetDefault("CAPTURE_PACKETFLIX_PORT", 5001)
 	viper.SetDefault("CAPTURE_REMOTE_HOSTNAME", "")
-	viper.SetDefault("CAPTURE_WIRESHARK_DOCKER_IMAGE", "ghcr.io/kaelemc/wireshark-vnc-docker:latest")
+	viper.SetDefault("CAPTURE_WIRESHARK_DOCKER_IMAGE", "ghcr.io/srl-labs/wireshark-vnc-docker:latest")
 	viper.SetDefault("CAPTURE_WIRESHARK_PULL_POLICY", "always")
 	viper.SetDefault("CAPTURE_WIRESHARK_SESSION_TTL", "2h")
 	viper.SetDefault("CAPTURE_EDGESHARK_EXTRA_ENV_VARS", "")


### PR DESCRIPTION
## Summary

- update the default Wireshark VNC image to the `srl-labs` GHCR namespace
- keep the configuration default and capture manager fallback aligned

## Why

The Wireshark VNC image moved from `ghcr.io/kaelemc` to `ghcr.io/srl-labs`, while the API server still selected the old image by default for standalone capture sessions.

## Impact

Default deployments now pull the organization-owned image. Explicit `CAPTURE_WIRESHARK_DOCKER_IMAGE` overrides remain unchanged.

## Testing

- `go test ./internal/config ./internal/capture`
