### PR TITLE
fix: sync lab hosts for containerized saves

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ API_USER_GROUP=clab_api # The API group name, if not defined, the user needs to 
 SUPERUSER_GROUP=clab_admins # The Superusers are allowed to see all labs
 CLAB_RUNTIME=docker # The runtime to use for the labs
 CLAB_LABS_ROOT= # Optional absolute root for managed lab workspaces, e.g. /var/lib/containerlab/labs
+CLAB_HOSTS_FILE= # Optional host-visible hosts file when the API server runs in a container
 LOG_LEVEL=debug
 CORS_ALLOWED_ORIGINS=https://localhost:5173 # Comma-separated list, e.g. https://localhost:5173,https://ui.example.com
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ docker run -d \
   ghcr.io/srl-labs/clab-api-server/clab-api-server:latest
 ```
 > [!NOTE]
-> Volume mounts enable Docker management, networking features, Linux PAM authentication, and user file storage. No containerlab binary is required - it's integrated as a Go library.
+> Volume mounts enable Docker management, networking features, Linux PAM authentication, and user file storage. Host PID mode also lets the API server keep the lab host's `/etc/hosts` entries synchronized. No containerlab binary is required - it's integrated as a Go library.
 
 This Docker example uses the default managed lab storage: each authenticated user's `~/.clab` directory from the mounted `/home`. To use a different root, add both `CLAB_LABS_ROOT` and a matching volume mount:
 
@@ -223,6 +223,7 @@ sudo systemctl status clab-api-server
 | `SUPERUSER_GROUP` | `clab_admins` | Linux group for elevated privileges |
 | `CLAB_RUNTIME` | `docker` | Container runtime used by Containerlab |
 | `CLAB_LABS_ROOT` | unset | Optional absolute root for managed lab workspaces. When set, users store labs under `$CLAB_LABS_ROOT/<username>/`; otherwise labs use `<home>/.clab/`. |
+| `CLAB_HOSTS_FILE` | unset | Optional absolute host-visible hosts file to synchronize. The container entrypoint detects `/proc/1/root/etc/hosts` automatically when running with host PID mode. |
 | `LOG_LEVEL` | `info` | Log verbosity (`debug`, `info`, `warn`, `error`) |
 | `CORS_ALLOWED_ORIGINS` | | Comma-separated browser origin allowlist (for standalone UI) |
 | `GIN_MODE` | `release` | Web framework mode (`debug` or `release`) |

--- a/docker/simple-container/entrypoint.sh
+++ b/docker/simple-container/entrypoint.sh
@@ -8,6 +8,15 @@ if [ -n "${CLAB_LABS_ROOT:-}" ]; then
   mkdir -p "$CLAB_LABS_ROOT"
 fi
 
+# With host PID mode, PID 1 exposes the lab host's filesystem. Keep host-side
+# Containerlab name resolution in sync in addition to this container's own
+# Docker-managed /etc/hosts file.
+if [ -z "${CLAB_HOSTS_FILE:-}" ] && [ -f /proc/1/root/etc/hosts ] && \
+  ! [ /etc/hosts -ef /proc/1/root/etc/hosts ]; then
+  export CLAB_HOSTS_FILE=/proc/1/root/etc/hosts
+  echo "Using host hosts file: $CLAB_HOSTS_FILE"
+fi
+
 mkdir -p /var/run/netns
 
 # Now execute the command passed to the container

--- a/internal/api/lab_handlers.go
+++ b/internal/api/lab_handlers.go
@@ -1112,7 +1112,7 @@ func SaveLabConfigHandler(c *gin.Context) {
 	log.Infof("SaveLabConfig user '%s': Config saved successfully for lab '%s'.", username, labName)
 	c.JSON(http.StatusOK, models.SaveConfigResponse{
 		Message: fmt.Sprintf("Configuration save command executed successfully for lab '%s'.", labName),
-		Output:  "Configuration saved via library",
+		Output:  "Configuration saved",
 	})
 }
 

--- a/internal/clab/hosts_file.go
+++ b/internal/clab/hosts_file.go
@@ -1,0 +1,228 @@
+package clab
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	clabconstants "github.com/srl-labs/containerlab/constants"
+	clabruntime "github.com/srl-labs/containerlab/runtime"
+	clabtypes "github.com/srl-labs/containerlab/types"
+	"golang.org/x/sys/unix"
+
+	"github.com/srl-labs/clab-api-server/internal/config"
+)
+
+const (
+	localHostsFile     = "/etc/hosts"
+	localHostsLockFile = "/run/lock/clab-hosts.lock"
+)
+
+var hostsFileMu sync.Mutex
+
+func syncLabHostsFiles(labName string, containers []clabruntime.GenericContainer) error {
+	if err := replaceLabHostsEntries(
+		localHostsFile,
+		localHostsLockFile,
+		labName,
+		containers,
+	); err != nil {
+		return fmt.Errorf("updating local hosts file: %w", err)
+	}
+
+	externalPath := strings.TrimSpace(config.AppConfig.ClabHostsFile)
+	if externalPath == "" || sameFile(localHostsFile, externalPath) {
+		return nil
+	}
+
+	if err := replaceLabHostsEntries(
+		externalPath,
+		hostsLockPath(externalPath),
+		labName,
+		containers,
+	); err != nil {
+		return fmt.Errorf("updating configured hosts file %q: %w", externalPath, err)
+	}
+
+	return nil
+}
+
+func removeLabHostsFiles(labName string) error {
+	externalPath := strings.TrimSpace(config.AppConfig.ClabHostsFile)
+	if externalPath == "" || sameFile(localHostsFile, externalPath) {
+		return nil
+	}
+
+	if err := removeLabHostsEntries(externalPath, hostsLockPath(externalPath), labName); err != nil {
+		return fmt.Errorf("updating configured hosts file %q: %w", externalPath, err)
+	}
+
+	return nil
+}
+
+func hostsLockPath(hostsPath string) string {
+	cleanPath := filepath.Clean(hostsPath)
+	if strings.HasSuffix(cleanPath, string(filepath.Separator)+"etc"+string(filepath.Separator)+"hosts") {
+		root := strings.TrimSuffix(cleanPath, string(filepath.Separator)+"etc"+string(filepath.Separator)+"hosts")
+		return filepath.Join(root, "run", "lock", "clab-hosts.lock")
+	}
+
+	return cleanPath + ".lock"
+}
+
+func sameFile(left, right string) bool {
+	leftInfo, leftErr := os.Stat(left)
+	rightInfo, rightErr := os.Stat(right)
+	return leftErr == nil && rightErr == nil && os.SameFile(leftInfo, rightInfo)
+}
+
+func replaceLabHostsEntries(
+	hostsPath,
+	lockPath,
+	labName string,
+	containers []clabruntime.GenericContainer,
+) error {
+	block := buildLabHostsBlock(labName, containers)
+	return updateLabHostsEntries(hostsPath, lockPath, labName, block)
+}
+
+func removeLabHostsEntries(hostsPath, lockPath, labName string) error {
+	return updateLabHostsEntries(hostsPath, lockPath, labName, nil)
+}
+
+func updateLabHostsEntries(hostsPath, lockPath, labName string, replacement []byte) error {
+	if strings.TrimSpace(labName) == "" {
+		return fmt.Errorf("lab name is required")
+	}
+
+	return withHostsFileLock(lockPath, func() error {
+		file, err := os.OpenFile(hostsPath, os.O_RDWR, 0)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		current, err := os.ReadFile(hostsPath)
+		if err != nil {
+			return err
+		}
+
+		updated, err := replaceMarkedBlock(current, labName, replacement)
+		if err != nil {
+			return err
+		}
+
+		if bytes.Equal(current, updated) {
+			return nil
+		}
+		if err := file.Truncate(0); err != nil {
+			return err
+		}
+		if _, err := file.Seek(0, 0); err != nil {
+			return err
+		}
+		if _, err := file.Write(updated); err != nil {
+			return err
+		}
+
+		return file.Sync()
+	})
+}
+
+func withHostsFileLock(lockPath string, fn func() error) error {
+	hostsFileMu.Lock()
+	defer hostsFileMu.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		return fmt.Errorf("creating hosts lock directory: %w", err)
+	}
+
+	lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening hosts lock file: %w", err)
+	}
+	defer lock.Close()
+
+	if err := unix.Flock(int(lock.Fd()), unix.LOCK_EX); err != nil {
+		return fmt.Errorf("locking hosts file: %w", err)
+	}
+
+	return fn()
+}
+
+func replaceMarkedBlock(current []byte, labName string, replacement []byte) ([]byte, error) {
+	startMarker := fmt.Sprintf("###### CLAB-%s-START ######", labName)
+	endMarker := fmt.Sprintf("###### CLAB-%s-END ######", labName)
+	lines := strings.SplitAfter(string(current), "\n")
+
+	var output strings.Builder
+	inBlock := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case !inBlock && trimmed == startMarker:
+			inBlock = true
+		case inBlock && trimmed == endMarker:
+			inBlock = false
+		case !inBlock:
+			output.WriteString(line)
+		}
+	}
+	if inBlock {
+		return nil, fmt.Errorf("hosts file contains an unterminated block for lab %q", labName)
+	}
+
+	if len(replacement) == 0 {
+		return []byte(output.String()), nil
+	}
+	if output.Len() > 0 && !strings.HasSuffix(output.String(), "\n") {
+		output.WriteByte('\n')
+	}
+	output.Write(replacement)
+
+	return []byte(output.String()), nil
+}
+
+func buildLabHostsBlock(labName string, containers []clabruntime.GenericContainer) []byte {
+	entries := make(clabtypes.HostEntries, 0, len(containers)*2)
+	for i := range containers {
+		container := &containers[i]
+		if len(container.Names) == 0 {
+			continue
+		}
+		if containerLab := container.Labels[clabconstants.Containerlab]; containerLab != "" && containerLab != labName {
+			continue
+		}
+
+		containerID := container.ID
+		if containerID == "" {
+			containerID = container.ShortID
+		}
+		description := fmt.Sprintf("Kind: %s", container.Labels[clabconstants.NodeKind])
+		if container.NetworkSettings.IPv4addr != "" {
+			entries = append(entries, clabtypes.NewHostEntry(
+				container.NetworkSettings.IPv4addr,
+				container.Names[0],
+				clabtypes.IpVersionV4,
+			).SetContainerID(containerID).SetDescription(description))
+		}
+		if container.NetworkSettings.IPv6addr != "" {
+			entries = append(entries, clabtypes.NewHostEntry(
+				container.NetworkSettings.IPv6addr,
+				container.Names[0],
+				clabtypes.IpVersionV6,
+			).SetContainerID(containerID).SetDescription(description))
+		}
+	}
+
+	var block strings.Builder
+	fmt.Fprintf(&block, "###### CLAB-%s-START ######\n", labName)
+	block.WriteString(entries.ToHostsConfig(clabtypes.IpVersionV4))
+	block.WriteString(entries.ToHostsConfig(clabtypes.IpVersionV6))
+	fmt.Fprintf(&block, "###### CLAB-%s-END ######\n", labName)
+
+	return []byte(block.String())
+}

--- a/internal/clab/hosts_file_test.go
+++ b/internal/clab/hosts_file_test.go
@@ -1,0 +1,114 @@
+package clab
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	clabconstants "github.com/srl-labs/containerlab/constants"
+	clabruntime "github.com/srl-labs/containerlab/runtime"
+)
+
+func TestReplaceLabHostsEntriesWritesReplacesAndRemovesBlock(t *testing.T) {
+	tempDir := t.TempDir()
+	hostsPath := filepath.Join(tempDir, "etc", "hosts")
+	lockPath := filepath.Join(tempDir, "run", "lock", "clab-hosts.lock")
+	if err := os.MkdirAll(filepath.Dir(hostsPath), 0o755); err != nil {
+		t.Fatalf("create hosts directory: %v", err)
+	}
+	baseline := "127.0.0.1 localhost\n###### CLAB-other-START ######\n192.0.2.1 other\n###### CLAB-other-END ######\n"
+	if err := os.WriteFile(hostsPath, []byte(baseline), 0o644); err != nil {
+		t.Fatalf("seed hosts file: %v", err)
+	}
+
+	containers := []clabruntime.GenericContainer{
+		{
+			Names:  []string{"clab-demo-leaf1"},
+			ID:     "1234567890abcdef",
+			Labels: map[string]string{clabconstants.Containerlab: "demo", clabconstants.NodeKind: "cisco_n9kv"},
+			NetworkSettings: clabruntime.GenericMgmtIPs{
+				IPv4addr: "172.20.20.2",
+				IPv6addr: "3fff:172:20:20::2",
+			},
+		},
+	}
+	if err := replaceLabHostsEntries(hostsPath, lockPath, "demo", containers); err != nil {
+		t.Fatalf("write lab hosts entries: %v", err)
+	}
+
+	assertHostsContains(t, hostsPath,
+		"###### CLAB-demo-START ######",
+		"172.20.20.2\tclab-demo-leaf1 1234567890ab\t# Kind: cisco_n9kv",
+		"3fff:172:20:20::2\tclab-demo-leaf1 1234567890ab\t# Kind: cisco_n9kv",
+		"###### CLAB-other-START ######",
+	)
+
+	containers[0].NetworkSettings.IPv4addr = "172.20.20.9"
+	if err := replaceLabHostsEntries(hostsPath, lockPath, "demo", containers); err != nil {
+		t.Fatalf("replace lab hosts entries: %v", err)
+	}
+	content := readHostsFile(t, hostsPath)
+	if strings.Contains(content, "172.20.20.2\tclab-demo-leaf1") {
+		t.Fatalf("old lab entry remained after replacement:\n%s", content)
+	}
+	if strings.Count(content, "###### CLAB-demo-START ######") != 1 {
+		t.Fatalf("expected one lab block after replacement:\n%s", content)
+	}
+
+	if err := removeLabHostsEntries(hostsPath, lockPath, "demo"); err != nil {
+		t.Fatalf("remove lab hosts entries: %v", err)
+	}
+	content = readHostsFile(t, hostsPath)
+	if strings.Contains(content, "CLAB-demo") || strings.Contains(content, "clab-demo-leaf1") {
+		t.Fatalf("lab entries remained after removal:\n%s", content)
+	}
+	if !strings.Contains(content, "###### CLAB-other-START ######") {
+		t.Fatalf("unrelated lab block was removed:\n%s", content)
+	}
+}
+
+func TestReplaceLabHostsEntriesRejectsUnterminatedBlock(t *testing.T) {
+	tempDir := t.TempDir()
+	hostsPath := filepath.Join(tempDir, "hosts")
+	lockPath := filepath.Join(tempDir, "hosts.lock")
+	original := "127.0.0.1 localhost\n###### CLAB-demo-START ######\n192.0.2.1 broken\n"
+	if err := os.WriteFile(hostsPath, []byte(original), 0o644); err != nil {
+		t.Fatalf("seed hosts file: %v", err)
+	}
+
+	err := replaceLabHostsEntries(hostsPath, lockPath, "demo", nil)
+	if err == nil {
+		t.Fatal("expected unterminated block error")
+	}
+	if content := readHostsFile(t, hostsPath); content != original {
+		t.Fatalf("hosts file changed after rejected update:\n%s", content)
+	}
+}
+
+func TestHostsLockPathUsesSameRoot(t *testing.T) {
+	got := hostsLockPath("/proc/1/root/etc/hosts")
+	want := "/proc/1/root/run/lock/clab-hosts.lock"
+	if got != want {
+		t.Fatalf("hostsLockPath() = %q, want %q", got, want)
+	}
+}
+
+func assertHostsContains(t *testing.T, path string, values ...string) {
+	t.Helper()
+	content := readHostsFile(t, path)
+	for _, value := range values {
+		if !strings.Contains(content, value) {
+			t.Fatalf("hosts file does not contain %q:\n%s", value, content)
+		}
+	}
+}
+
+func readHostsFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hosts file: %v", err)
+	}
+	return string(content)
+}

--- a/internal/clab/service.go
+++ b/internal/clab/service.go
@@ -296,6 +296,11 @@ type SaveOptions struct {
 	NodeFilter []string
 }
 
+type nodeConfigSaver interface {
+	GetShortName() string
+	SaveConfig(context.Context) (*clabnodes.SaveConfigResult, error)
+}
+
 // InspectOptions contains options for inspecting labs.
 type InspectOptions struct {
 	LabName  string
@@ -590,6 +595,9 @@ func (s *Service) Deploy(ctx context.Context, opts DeployOptions) ([]clabruntime
 	if err != nil {
 		return nil, fmt.Errorf("deployment failed: %w", err)
 	}
+	if err := syncLabHostsFiles(labName, containers); err != nil {
+		return nil, fmt.Errorf("deployment completed but host name resolution setup failed: %w", err)
+	}
 
 	log.Info("Lab deployed successfully",
 		"username", opts.Username,
@@ -657,6 +665,7 @@ func (s *Service) Apply(ctx context.Context, opts ApplyOptions) (*clabcore.Apply
 	)
 
 	var result *clabcore.ApplyResult
+	var containers []clabruntime.GenericContainer
 	err = func() error {
 		containerlabInitMu.Lock()
 		defer containerlabInitMu.Unlock()
@@ -666,6 +675,11 @@ func (s *Service) Apply(ctx context.Context, opts ApplyOptions) (*clabcore.Apply
 
 		var applyErr error
 		result, applyErr = clab.Apply(ctx, applyOpts)
+		if applyErr != nil || opts.DryRun {
+			return applyErr
+		}
+
+		containers, applyErr = clab.ListContainers(ctx, clabcore.WithListLabName(clab.Config.Name))
 		return applyErr
 	}()
 	if err != nil {
@@ -673,6 +687,11 @@ func (s *Service) Apply(ctx context.Context, opts ApplyOptions) (*clabcore.Apply
 	}
 	if result != nil && strings.TrimSpace(result.LabName) == "" {
 		result.LabName = clab.Config.Name
+	}
+	if !opts.DryRun {
+		if err := syncLabHostsFiles(clab.Config.Name, containers); err != nil {
+			return nil, fmt.Errorf("apply completed but host name resolution setup failed: %w", err)
+		}
 	}
 
 	return result, nil
@@ -769,6 +788,9 @@ func (s *Service) Destroy(ctx context.Context, opts DestroyOptions) error {
 	// Destroy the lab
 	if err := clab.Destroy(ctx, destroyOpts...); err != nil {
 		return fmt.Errorf("destroy failed: %w", err)
+	}
+	if err := removeLabHostsFiles(clab.Config.Name); err != nil {
+		return fmt.Errorf("lab destroyed but host name resolution cleanup failed: %w", err)
 	}
 
 	log.Info("Lab destroyed successfully",
@@ -1342,8 +1364,25 @@ func (s *Service) SaveConfig(ctx context.Context, opts SaveOptions) error {
 		"topoPath", opts.TopoPath,
 	)
 
-	// Save config for each node
-	if err := clab.Save(ctx); err != nil {
+	containers, err := clab.ListContainers(ctx, clabcore.WithListLabName(clab.Config.Name))
+	if err != nil {
+		return fmt.Errorf("failed to resolve lab containers: %w", err)
+	}
+	if err := syncLabHostsFiles(clab.Config.Name, containers); err != nil {
+		return fmt.Errorf("failed to prepare host name resolution: %w", err)
+	}
+
+	if clab.Config.Mgmt != nil {
+		if err := clablinks.SetMgmtNetUnderlyingBridge(clab.Config.Mgmt.Bridge); err != nil {
+			return fmt.Errorf("failed to configure management bridge: %w", err)
+		}
+	}
+
+	savers := make([]nodeConfigSaver, 0, len(clab.Nodes))
+	for _, node := range clab.Nodes {
+		savers = append(savers, node)
+	}
+	if err := saveNodeConfigs(ctx, savers); err != nil {
 		return fmt.Errorf("save failed: %w", err)
 	}
 
@@ -1352,6 +1391,31 @@ func (s *Service) SaveConfig(ctx context.Context, opts SaveOptions) error {
 	)
 
 	return nil
+}
+
+func saveNodeConfigs(ctx context.Context, nodes []nodeConfigSaver) error {
+	var wg sync.WaitGroup
+	errorsCh := make(chan error, len(nodes))
+
+	for _, node := range nodes {
+		wg.Add(1)
+		go func(node nodeConfigSaver) {
+			defer wg.Done()
+			if _, err := node.SaveConfig(ctx); err != nil {
+				errorsCh <- fmt.Errorf("node %q: %w", node.GetShortName(), err)
+			}
+		}(node)
+	}
+
+	wg.Wait()
+	close(errorsCh)
+
+	var saveErrors []error
+	for err := range errorsCh {
+		saveErrors = append(saveErrors, err)
+	}
+
+	return errors.Join(saveErrors...)
 }
 
 // CACreateOptions contains options for creating a CA.

--- a/internal/clab/service_test.go
+++ b/internal/clab/service_test.go
@@ -11,7 +11,23 @@ import (
 
 	gotc "github.com/florianl/go-tc"
 	clabcore "github.com/srl-labs/containerlab/core"
+	clabnodes "github.com/srl-labs/containerlab/nodes"
 )
+
+type fakeNodeConfigSaver struct {
+	name   string
+	err    error
+	called bool
+}
+
+func (n *fakeNodeConfigSaver) GetShortName() string {
+	return n.name
+}
+
+func (n *fakeNodeConfigSaver) SaveConfig(context.Context) (*clabnodes.SaveConfigResult, error) {
+	n.called = true
+	return nil, n.err
+}
 
 func TestResolveTopologySourceUsesContainerlabRendering(t *testing.T) {
 	current, err := user.Current()
@@ -192,6 +208,34 @@ func TestSetProcessOwnerEnvSetsSudoIDsForExistingUser(t *testing.T) {
 	}
 	if got := os.Getenv("SUDO_GID"); got != current.Gid {
 		t.Fatalf("SUDO_GID = %q, want %q", got, current.Gid)
+	}
+}
+
+func TestSaveNodeConfigsReturnsAllNodeErrors(t *testing.T) {
+	leaf1 := &fakeNodeConfigSaver{name: "leaf1", err: errors.New("connection refused")}
+	leaf2 := &fakeNodeConfigSaver{name: "leaf2", err: errors.New("authentication failed")}
+
+	err := saveNodeConfigs(context.Background(), []nodeConfigSaver{leaf1, leaf2})
+	if err == nil {
+		t.Fatal("saveNodeConfigs unexpectedly returned nil")
+	}
+	for _, want := range []string{"leaf1", "connection refused", "leaf2", "authentication failed"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("saveNodeConfigs error = %q, want it to contain %q", err, want)
+		}
+	}
+	if !leaf1.called || !leaf2.called {
+		t.Fatalf("expected every node save to run, called leaf1=%t leaf2=%t", leaf1.called, leaf2.called)
+	}
+}
+
+func TestSaveNodeConfigsReturnsNilWhenAllNodesSucceed(t *testing.T) {
+	node := &fakeNodeConfigSaver{name: "leaf1"}
+	if err := saveNodeConfigs(context.Background(), []nodeConfigSaver{node}); err != nil {
+		t.Fatalf("saveNodeConfigs returned error: %v", err)
+	}
+	if !node.called {
+		t.Fatal("expected node save to run")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	SuperuserGroup               string        `mapstructure:"SUPERUSER_GROUP"` // Group for elevated privileges
 	ClabRuntime                  string        `mapstructure:"CLAB_RUNTIME"`
 	ClabLabsRoot                 string        `mapstructure:"CLAB_LABS_ROOT"`
+	ClabHostsFile                string        `mapstructure:"CLAB_HOSTS_FILE"`
 	CapturePacketflixPort        int           `mapstructure:"CAPTURE_PACKETFLIX_PORT"`
 	CaptureRemoteHostname        string        `mapstructure:"CAPTURE_REMOTE_HOSTNAME"`
 	CaptureWiresharkDockerImage  string        `mapstructure:"CAPTURE_WIRESHARK_DOCKER_IMAGE"`
@@ -56,6 +57,7 @@ func LoadConfig(envFilePath string) error {
 	viper.SetDefault("SUPERUSER_GROUP", "")
 	viper.SetDefault("CLAB_RUNTIME", "docker")
 	viper.SetDefault("CLAB_LABS_ROOT", "")
+	viper.SetDefault("CLAB_HOSTS_FILE", "")
 	viper.SetDefault("CAPTURE_PACKETFLIX_PORT", 5001)
 	viper.SetDefault("CAPTURE_REMOTE_HOSTNAME", "")
 	viper.SetDefault("CAPTURE_WIRESHARK_DOCKER_IMAGE", "ghcr.io/srl-labs/wireshark-vnc-docker:latest")
@@ -112,6 +114,17 @@ func LoadConfig(envFilePath string) error {
 			return fmt.Errorf("CLAB_LABS_ROOT must be an absolute path")
 		}
 		AppConfig.ClabLabsRoot = filepath.Clean(AppConfig.ClabLabsRoot)
+	}
+
+	AppConfig.ClabHostsFile = strings.TrimSpace(AppConfig.ClabHostsFile)
+	if AppConfig.ClabHostsFile != "" {
+		if strings.HasPrefix(AppConfig.ClabHostsFile, "~") {
+			return fmt.Errorf("CLAB_HOSTS_FILE must be an absolute path; '~' is not supported")
+		}
+		if !filepath.IsAbs(AppConfig.ClabHostsFile) {
+			return fmt.Errorf("CLAB_HOSTS_FILE must be an absolute path")
+		}
+		AppConfig.ClabHostsFile = filepath.Clean(AppConfig.ClabHostsFile)
 	}
 
 	// No need to convert - the value is already a time.Duration thanks to the type in the struct

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -45,6 +45,9 @@ func TestLoadConfigDefaultsEnableTLSAutoCert(t *testing.T) {
 	if AppConfig.ClabLabsRoot != "" {
 		t.Fatalf("expected CLAB_LABS_ROOT default to be empty, got %q", AppConfig.ClabLabsRoot)
 	}
+	if AppConfig.ClabHostsFile != "" {
+		t.Fatalf("expected CLAB_HOSTS_FILE default to be empty, got %q", AppConfig.ClabHostsFile)
+	}
 }
 
 func TestLoadConfigTerminalMaxSessionsPerUserOverride(t *testing.T) {
@@ -132,5 +135,49 @@ func TestLoadConfigRejectsTildeClabLabsRoot(t *testing.T) {
 	viper.Reset()
 	if err := LoadConfig(".env"); err == nil {
 		t.Fatal("expected LoadConfig to reject tilde CLAB_LABS_ROOT")
+	}
+}
+
+func TestLoadConfigClabHostsFileOverride(t *testing.T) {
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatalf("chdir temp dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWd)
+		viper.Reset()
+	})
+
+	t.Setenv("CLAB_HOSTS_FILE", "/proc/1/root/etc/../etc/hosts")
+	viper.Reset()
+	if err := LoadConfig(".env"); err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+
+	if AppConfig.ClabHostsFile != "/proc/1/root/etc/hosts" {
+		t.Fatalf("expected CLAB_HOSTS_FILE to be cleaned, got %q", AppConfig.ClabHostsFile)
+	}
+}
+
+func TestLoadConfigRejectsRelativeClabHostsFile(t *testing.T) {
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatalf("chdir temp dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWd)
+		viper.Reset()
+	})
+
+	t.Setenv("CLAB_HOSTS_FILE", "relative/hosts")
+	viper.Reset()
+	if err := LoadConfig(".env"); err == nil {
+		t.Fatal("expected LoadConfig to reject relative CLAB_HOSTS_FILE")
 	}
 }

--- a/tests_go/lab_config_suite_test.go
+++ b/tests_go/lab_config_suite_test.go
@@ -2,9 +2,12 @@
 package tests_go
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -62,6 +65,19 @@ func (s *LabConfigSuite) TestInspectLabInterfaces() {
 func (s *LabConfigSuite) TestSaveLabConfig() {
 	labName, userHeaders := s.setupEphemeralLab()
 	defer s.cleanupLab(labName, true)
+
+	container := s.firstContainerInLab(labName, userHeaders)
+	wantPrefix, err := netip.ParsePrefix(container.IPv4Address)
+	s.Require().NoError(err, "Invalid container IPv4 address %q", container.IPv4Address)
+
+	// The API server is commonly containerized. Resolve the node from the test runner
+	// (the lab host) to ensure deployment did not update only the API container's hosts file.
+	resolveCtx, cancel := context.WithTimeout(context.Background(), s.cfg.RequestTimeout)
+	defer cancel()
+	resolvedAddresses, err := net.DefaultResolver.LookupHost(resolveCtx, container.Name)
+	s.Require().NoError(err, "Lab host cannot resolve container %q", container.Name)
+	s.Require().Contains(resolvedAddresses, wantPrefix.Addr().String(),
+		"Container %q did not resolve to its management address", container.Name)
 
 	s.logTest("Saving configuration for lab '%s'", labName)
 


### PR DESCRIPTION
Deploying through a containerized API currently updates only the container's `/etc/hosts`, leaving lab hostnames unresolved on the Linux host. Saving configurations can also report success when individual node saves fail. This change synchronizes the lab entries in both environments and returns node-level failures to the caller.

- Refresh hostname entries on deploy, apply, and save; remove the host-side block on destroy.
- Detect the host hosts file through host PID mode, with `CLAB_HOSTS_FILE` as an explicit override.
- Use Containerlab's node-provided host entries to retain distributed SR OS management aliases.
- Keep the complete lab's hostname entries when saving only selected nodes.
- Add regression coverage for SR OS aliases, filtered saves, cleanup, and failed saves. CI now also runs the save integration tests against the Docker image.

Example request:

```sh
curl -X POST -H "Authorization: Bearer $TOKEN" \
  https://localhost:8090/api/v1/labs/example/save
```

A node save failure now returns HTTP 500 with the node name and underlying error instead of a successful save response.

Validation against current main (Go 1.27.1 / Containerlab 0.79.0):

- `task build`
- `go test ./internal/...`
- `go test -race ./internal/clab ./internal/config`
- `go vet ./internal/...`
- Full local suite plus targeted reruns: 254 passed, one root-only test skipped. The three initial environment failures passed with the expected 24-hour JWT setting, a cached capture image, and an explicit topology filename for an existing checkout.
- Containerized save and filtered-save integration tests passed, including host resolution and destroy cleanup.
- Real SR Linux 25.10.3: a running configuration change was persisted into `config.json`; saving a stopped node returned HTTP 500 with its name; cleanup removed both hosts-file blocks.

No Cisco N9kv image was available for a vendor-specific retest.

Closes #148
